### PR TITLE
Fixed #44

### DIFF
--- a/lib/flutter_image_compress.dart
+++ b/lib/flutter_image_compress.dart
@@ -185,7 +185,7 @@ Future<ImageInfo> getImageInfo(BuildContext context, ImageProvider provider,
   void errorListener(dynamic exception, StackTrace stackTrace) {
     completer.complete(null);
     FlutterError.reportError(new FlutterErrorDetails(
-      context: 'image load failed ',
+      context: DiagnosticsNode.message('image load failed '),
       library: 'flutter_image_compress',
       exception: exception,
       stack: stackTrace,


### PR DESCRIPTION
Fixed #44 
This error occurs on master channel 


`flutter doctor -v`:
```
[✓] Flutter (Channel master, v1.6.1-pre.32, on Mac OS X 10.14.5 18F131a, locale en-RU)
    • Flutter version 1.6.1-pre.32 at /Users/vanelizarov/flutter
    • Framework revision 4aaeb4e11f (7 hours ago), 2019-05-16 23:52:38 -0400
    • Engine revision 065fe5b210
    • Dart version 2.3.1 (build 2.3.1-dev.0.0 5ffff98440)

[✓] Android toolchain - develop for Android devices (Android SDK version 28.0.3)
    • Android SDK at /Users/vanelizarov/Library/Android/sdk
    • Android NDK location not configured (optional; useful for native profiling support)
    • Platform android-28, build-tools 28.0.3
    • Java binary at: /Applications/Android Studio.app/Contents/jre/jdk/Contents/Home/bin/java
    • Java version OpenJDK Runtime Environment (build 1.8.0_152-release-1248-b01)
    • All Android licenses accepted.

[✓] iOS toolchain - develop for iOS devices (Xcode 10.2.1)
    • Xcode at /Applications/Xcode.app/Contents/Developer
    • Xcode 10.2.1, Build version 10E1001
    • ios-deploy 1.9.4
    • CocoaPods version 1.5.3

[✓] Android Studio (version 3.3)
    • Android Studio at /Applications/Android Studio.app/Contents
    • Flutter plugin version 33.4.1
    • Dart plugin version 182.5215
    • Java version OpenJDK Runtime Environment (build 1.8.0_152-release-1248-b01)

[✓] VS Code (version 1.33.1)
    • VS Code at /Applications/Visual Studio Code.app/Contents
    • Flutter extension version 3.0.2

[✓] Connected device (2 available)
    • Android SDK built for x86 • emulator-5554                        • android-x86 • Android 9 (API 28) (emulator)
    • iPhone Xʀ                 • D71EC0B3-B4A2-41DB-9C0C-878DCDD474E3 • ios         • com.apple.CoreSimulator.SimRuntime.iOS-12-2 (simulator)

• No issues found!
```

I think it will be correct to merge this PR when that `FlutterErrorDetails` API change lands on `stable`