### PR TITLE
Running outside of the main UI thread

### DIFF
--- a/android/src/main/kotlin/com/example/flutterimagecompress/FlutterImageCompressPlugin.kt
+++ b/android/src/main/kotlin/com/example/flutterimagecompress/FlutterImageCompressPlugin.kt
@@ -8,7 +8,7 @@ import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
 import io.flutter.plugin.common.PluginRegistry.Registrar
 
-class FlutterImageCompressPlugin(val registrar: Registrar) : MethodCallHandler {
+class FlutterImageCompressPlugin(private val registrar: Registrar) : MethodCallHandler {
     companion object {
         @JvmStatic
         fun registerWith(registrar: Registrar): Unit {
@@ -22,8 +22,8 @@ class FlutterImageCompressPlugin(val registrar: Registrar) : MethodCallHandler {
     override fun onMethodCall(call: MethodCall, result: Result): Unit {
         when (call.method) {
             "showLog" -> result.success(handleLog(call))
-            "compressWithList" -> CompressListHandler(call, result).handle(registrar.activity())
-            "compressWithFile" -> CompressFileHandler(call, result).handle(registrar.activity())
+            "compressWithList" -> CompressListHandler(call, result).handle(registrar)
+            "compressWithFile" -> CompressFileHandler(call, result).handle(registrar)
             "compressWithFileAndGetFile" -> CompressFileHandler(call, result).handleGetFile()
             else -> result.notImplemented()
         }

--- a/android/src/main/kotlin/com/example/flutterimagecompress/core/CompressFileHandler.kt
+++ b/android/src/main/kotlin/com/example/flutterimagecompress/core/CompressFileHandler.kt
@@ -1,6 +1,5 @@
 package com.example.flutterimagecompress.core
 
-import android.app.Activity
 import android.graphics.BitmapFactory
 import com.example.flutterimagecompress.FlutterImageCompressPlugin
 import com.example.flutterimagecompress.exif.Exif
@@ -8,6 +7,7 @@ import com.example.flutterimagecompress.exif.ExifKeeper
 import com.example.flutterimagecompress.ext.compress
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
+import io.flutter.plugin.common.PluginRegistry
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.util.concurrent.Executors
@@ -19,7 +19,7 @@ class CompressFileHandler(private val call: MethodCall, result: MethodChannel.Re
         private val executor = Executors.newFixedThreadPool(5)
     }
 
-    fun handle(activity: Activity) {
+    fun handle(registrar: PluginRegistry.Registrar) {
         executor.execute {
             val args: List<Any> = call.arguments as List<Any>
             val file = args[0] as String
@@ -52,7 +52,10 @@ class CompressFileHandler(private val call: MethodCall, result: MethodChannel.Re
                 if (keepExif) {
                     val byteArrayOutputStream = ByteArrayOutputStream()
                     byteArrayOutputStream.write(array)
-                    val outputStream = ExifKeeper(file).writeToOutputStream(activity, byteArrayOutputStream)
+                    val outputStream = ExifKeeper(file).writeToOutputStream(
+                            registrar.context().applicationContext,
+                            byteArrayOutputStream
+                    )
                     reply(outputStream.toByteArray())
                     return@execute
                 }

--- a/android/src/main/kotlin/com/example/flutterimagecompress/core/CompressListHandler.kt
+++ b/android/src/main/kotlin/com/example/flutterimagecompress/core/CompressListHandler.kt
@@ -1,6 +1,5 @@
 package com.example.flutterimagecompress.core
 
-import android.app.Activity
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import com.example.flutterimagecompress.FlutterImageCompressPlugin
@@ -11,6 +10,7 @@ import com.example.flutterimagecompress.ext.convertFormatIndexToFormat
 import com.example.flutterimagecompress.ext.rotate
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
+import io.flutter.plugin.common.PluginRegistry
 import java.io.ByteArrayOutputStream
 import java.util.concurrent.Executors
 
@@ -21,7 +21,7 @@ class CompressListHandler(private val call: MethodCall, result: MethodChannel.Re
         private val executor = Executors.newFixedThreadPool(5)
     }
 
-    fun handle(activity: Activity) {
+    fun handle(registrar: PluginRegistry.Registrar) {
         executor.execute {
             val args: List<Any> = call.arguments as List<Any>
             val arr = args[0] as ByteArray
@@ -47,7 +47,10 @@ class CompressListHandler(private val call: MethodCall, result: MethodChannel.Re
                 if (keepExif) {
                     val keeper = ExifKeeper(arr)
                     val outputStream = ByteArrayOutputStream().apply { write(bytes) }
-                    val resultStream = keeper.writeToOutputStream(activity, outputStream)
+                    val resultStream = keeper.writeToOutputStream(
+                            registrar.context().applicationContext,
+                            outputStream
+                    )
                     reply(resultStream.toByteArray())
                     return@execute
                 }

--- a/android/src/main/kotlin/com/example/flutterimagecompress/exif/ExifKeeper.java
+++ b/android/src/main/kotlin/com/example/flutterimagecompress/exif/ExifKeeper.java
@@ -1,7 +1,7 @@
 package com.example.flutterimagecompress.exif;
 /// create 2019-07-02 by cai
 
-import android.app.Activity;
+import android.content.Context;
 import android.util.Log;
 
 import androidx.exifinterface.media.ExifInterface;
@@ -55,10 +55,26 @@ public class ExifKeeper {
         this.oldExif = new ExifInterface(new ByteArrayInputStream(buf));
     }
 
-    public ByteArrayOutputStream writeToOutputStream(Activity activity, ByteArrayOutputStream outputStream) {
+    private static void copyExif(ExifInterface oldExif, ExifInterface newExif) {
+        for (String attribute : attributes) {
+            setIfNotNull(oldExif, newExif, attribute);
+        }
+        try {
+            newExif.saveAttributes();
+        } catch (IOException e) {
+        }
+    }
+
+    private static void setIfNotNull(ExifInterface oldExif, ExifInterface newExif, String property) {
+        if (oldExif.getAttribute(property) != null) {
+            newExif.setAttribute(property, oldExif.getAttribute(property));
+        }
+    }
+
+    public ByteArrayOutputStream writeToOutputStream(Context context, ByteArrayOutputStream outputStream) {
         try {
             String uuid = UUID.randomUUID().toString();
-            File file = new File(activity.getCacheDir(), uuid + ".jpg");
+            File file = new File(context.getCacheDir(), uuid + ".jpg");
             FileOutputStream fileOutputStream = new FileOutputStream(file);
             IOUtils.write(outputStream.toByteArray(), fileOutputStream);
             fileOutputStream.close();
@@ -83,16 +99,6 @@ public class ExifKeeper {
         }
     }
 
-    private static void copyExif(ExifInterface oldExif, ExifInterface newExif) {
-        for (String attribute : attributes) {
-            setIfNotNull(oldExif, newExif, attribute);
-        }
-        try {
-            newExif.saveAttributes();
-        } catch (IOException e) {
-        }
-    }
-
     public void copyExifToFile(File file) {
         try {
             ExifInterface newExif = new ExifInterface(file.getAbsolutePath());
@@ -102,11 +108,5 @@ public class ExifKeeper {
             return;
         }
 
-    }
-
-    private static void setIfNotNull(ExifInterface oldExif, ExifInterface newExif, String property) {
-        if (oldExif.getAttribute(property) != null) {
-            newExif.setAttribute(property, oldExif.getAttribute(property));
-        }
     }
 }


### PR DESCRIPTION
When using this plugin with android_alarm_manager, there following error occurs:

```
E/MethodChannel#flutter_image_compress( 5479): Failed to handle method call
E/MethodChannel#flutter_image_compress( 5479): java.lang.IllegalStateException: registrar.activity() must not be null
E/MethodChannel#flutter_image_compress( 5479): 	at com.example.flutterimagecompress.FlutterImageCompressPlugin.onMethodCall(FlutterImageCompressPlugin.kt:26)
E/MethodChannel#flutter_image_compress( 5479): 	at io.flutter.plugin.common.MethodChannel$IncomingMethodCallHandler.onMessage(MethodChannel.java:222)
E/MethodChannel#flutter_image_compress( 5479): 	at io.flutter.embedding.engine.dart.DartMessenger.handleMessageFromDart(DartMessenger.java:96)
E/MethodChannel#flutter_image_compress( 5479): 	at io.flutter.embedding.engine.FlutterJNI.handlePlatformMessage(FlutterJNI.java:643)
E/MethodChannel#flutter_image_compress( 5479): 	at android.os.MessageQueue.nativePollOnce(Native Method)
E/MethodChannel#flutter_image_compress( 5479): 	at android.os.MessageQueue.next(MessageQueue.java:326)
E/MethodChannel#flutter_image_compress( 5479): 	at android.os.Looper.loop(Looper.java:160)
E/MethodChannel#flutter_image_compress( 5479): 	at android.app.ActivityThread.main(ActivityThread.java:6863)
E/MethodChannel#flutter_image_compress( 5479): 	at java.lang.reflect.Method.invoke(Native Method)
E/MethodChannel#flutter_image_compress( 5479): 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:537)
E/MethodChannel#flutter_image_compress( 5479): 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:858)
I/flutter ( 5479): creating thumbnail from /storage/emulated/0/DCIM/Camera/IMG_20190710_113827.jpg
E/MethodChannel#flutter_image_compress( 5479): Failed to handle method call
E/MethodChannel#flutter_image_compress( 5479): java.lang.IllegalStateException: registrar.activity() must not be null
E/MethodChannel#flutter_image_compress( 5479): 	at com.example.flutterimagecompress.FlutterImageCompressPlugin.onMethodCall(FlutterImageCompressPlugin.kt:26)
E/MethodChannel#flutter_image_compress( 5479): 	at io.flutter.plugin.common.MethodChannel$IncomingMethodCallHandler.onMessage(MethodChannel.java:222)
E/MethodChannel#flutter_image_compress( 5479): 	at io.flutter.embedding.engine.dart.DartMessenger.handleMessageFromDart(DartMessenger.java:96)
E/MethodChannel#flutter_image_compress( 5479): 	at io.flutter.embedding.engine.FlutterJNI.handlePlatformMessage(FlutterJNI.java:643)
E/MethodChannel#flutter_image_compress( 5479): 	at android.os.MessageQueue.nativePollOnce(Native Method)
E/MethodChannel#flutter_image_compress( 5479): 	at android.os.MessageQueue.next(MessageQueue.java:326)
E/MethodChannel#flutter_image_compress( 5479): 	at android.os.Looper.loop(Looper.java:160)
E/MethodChannel#flutter_image_compress( 5479): 	at android.app.ActivityThread.main(ActivityThread.java:6863)
E/MethodChannel#flutter_image_compress( 5479): 	at java.lang.reflect.Method.invoke(Native Method)
E/MethodChannel#flutter_image_compress( 5479): 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:537)
E/MethodChannel#flutter_image_compress( 5479): 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:858)
```

This PR fixes this by using
`registrar.context().applicationContext`