### PR TITLE
A fix for #77

### DIFF
--- a/android/src/main/kotlin/com/example/flutterimagecompress/core/CompressFileHandler.kt
+++ b/android/src/main/kotlin/com/example/flutterimagecompress/core/CompressFileHandler.kt
@@ -31,6 +31,7 @@ class CompressFileHandler(private val call: MethodCall, result: MethodChannel.Re
             val autoCorrectionAngle = args[5] as Boolean
             val format = args[6] as Int
             val keepExif = args[7] as Boolean
+            val inSampleSize = args[8] as Int
 
             val exifRotate =
                     if (autoCorrectionAngle) {
@@ -49,8 +50,9 @@ class CompressFileHandler(private val call: MethodCall, result: MethodChannel.Re
                 val options = BitmapFactory.Options()
                 options.inJustDecodeBounds = false
                 options.inPreferredConfig = Bitmap.Config.RGB_565
+                options.inSampleSize = inSampleSize
                 options.inDither = true
-                val bitmap = BitmapFactory.decodeFile(file,options)
+                val bitmap = BitmapFactory.decodeFile(file, options)
                 val array = bitmap.compress(minWidth, minHeight, quality, rotate + exifRotate, format)
 
                 if (keepExif) {
@@ -91,13 +93,15 @@ class CompressFileHandler(private val call: MethodCall, result: MethodChannel.Re
                     }
             val format = args[7] as Int
             val keepExif = args[8] as Boolean
+            val inSampleSize = args[9] as Int
 
             try {
                 val options = BitmapFactory.Options()
                 options.inJustDecodeBounds = false
                 options.inPreferredConfig = Bitmap.Config.RGB_565
+                options.inSampleSize = inSampleSize
                 options.inDither = true
-                val bitmap = BitmapFactory.decodeFile(file,options)
+                val bitmap = BitmapFactory.decodeFile(file, options)
                 val outputStream = File(targetPath).outputStream()
                 outputStream.use {
                     if (exifRotate == 270 || exifRotate == 90) {

--- a/android/src/main/kotlin/com/example/flutterimagecompress/core/CompressFileHandler.kt
+++ b/android/src/main/kotlin/com/example/flutterimagecompress/core/CompressFileHandler.kt
@@ -1,6 +1,7 @@
 package com.example.flutterimagecompress.core
 
 import android.graphics.BitmapFactory
+import android.graphics.Bitmap
 import com.example.flutterimagecompress.FlutterImageCompressPlugin
 import com.example.flutterimagecompress.exif.Exif
 import com.example.flutterimagecompress.exif.ExifKeeper
@@ -45,8 +46,11 @@ class CompressFileHandler(private val call: MethodCall, result: MethodChannel.Re
                     minWidth = minHeight
                     minHeight = tmp
                 }
-
-                val bitmap = BitmapFactory.decodeFile(file)
+                val options = BitmapFactory.Options()
+                options.inJustDecodeBounds = false
+                options.inPreferredConfig = Bitmap.Config.RGB_565
+                options.inDither = true
+                val bitmap = BitmapFactory.decodeFile(file,options)
                 val array = bitmap.compress(minWidth, minHeight, quality, rotate + exifRotate, format)
 
                 if (keepExif) {
@@ -89,7 +93,11 @@ class CompressFileHandler(private val call: MethodCall, result: MethodChannel.Re
             val keepExif = args[8] as Boolean
 
             try {
-                val bitmap = BitmapFactory.decodeFile(file)
+                val options = BitmapFactory.Options()
+                options.inJustDecodeBounds = false
+                options.inPreferredConfig = Bitmap.Config.RGB_565
+                options.inDither = true
+                val bitmap = BitmapFactory.decodeFile(file,options)
                 val outputStream = File(targetPath).outputStream()
                 outputStream.use {
                     if (exifRotate == 270 || exifRotate == 90) {

--- a/lib/flutter_image_compress.dart
+++ b/lib/flutter_image_compress.dart
@@ -73,6 +73,7 @@ class FlutterImageCompress {
     String path, {
     int minWidth = 1920,
     int minHeight = 1080,
+    int inSampleSize = 1,
     int quality = 95,
     int rotate = 0,
     bool autoCorrectionAngle = true,
@@ -95,6 +96,7 @@ class FlutterImageCompress {
       autoCorrectionAngle,
       _convertTypeToInt(format),
       keepExif,
+      inSampleSize,
     ]);
     return convertDynamic(result);
   }
@@ -105,6 +107,7 @@ class FlutterImageCompress {
     String targetPath, {
     int minWidth = 1920,
     int minHeight = 1080,
+    int inSampleSize = 1,
     int quality = 95,
     int rotate = 0,
     bool autoCorrectionAngle = true,
@@ -130,6 +133,7 @@ class FlutterImageCompress {
       autoCorrectionAngle,
       _convertTypeToInt(format),
       keepExif,
+      inSampleSize,
     ]);
 
     if (result == null) {


### PR DESCRIPTION
```dart
double _scale = _getScale();
await FlutterImageCompress.compressAndGetFile(
    _file.absolute.path,
    _path,
    minWidth: _isLandscape ? 1920 : 1080,
    minHeight: _isLandscape ? 1080 : 1920,
    inSampleSize: _scale.toInt(), //scale to 1/_scale
    quality: 88,
);
```