### PR TITLE
Fix broken iOS resize logic

### DIFF
--- a/ios/Classes/UIImage+scale.m
+++ b/ios/Classes/UIImage+scale.m
@@ -11,15 +11,16 @@
     float actualWidth = self.size.width;
     float imgRatio = actualWidth/actualHeight;
     float maxRatio = minWidth/minHeight;
+    float scaleRatio = 1;
     
     if(imgRatio < maxRatio) {
-        imgRatio = minWidth / actualWidth;
+        scaleRatio = minWidth / actualWidth;
     } else {
-        imgRatio = minHeight / actualHeight;
+        scaleRatio = minHeight / actualHeight;
     }
 
-    actualWidth = floor(imgRatio * actualWidth);
-    actualHeight = floor(imgRatio * actualHeight);
+    actualWidth = floor(scaleRatio * actualWidth);
+    actualHeight = floor(scaleRatio * actualHeight);
     
     CGRect rect = CGRectMake(0.0, 0.0, actualWidth, actualHeight);
     UIGraphicsBeginImageContext(rect.size);
@@ -28,7 +29,7 @@
     UIGraphicsEndImageContext();
     
     if([FlutterImageCompressPlugin showLog]){
-        NSLog(@"scale = %.2f", imgRatio);
+        NSLog(@"scale = %.2f", scaleRatio);
         NSLog(@"dst width = %.2f", rect.size.width);
         NSLog(@"dst height = %.2f", rect.size.height);
     }

--- a/ios/Classes/UIImage+scale.m
+++ b/ios/Classes/UIImage+scale.m
@@ -18,6 +18,7 @@
     } else {
         scaleRatio = minHeight / actualHeight;
     }
+    scaleRatio = fminf(1, scaleRatio);
 
     actualWidth = floor(scaleRatio * actualWidth);
     actualHeight = floor(scaleRatio * actualHeight);

--- a/ios/Classes/UIImage+scale.m
+++ b/ios/Classes/UIImage+scale.m
@@ -14,16 +14,16 @@
     
     if(imgRatio != maxRatio) {
         if(imgRatio < maxRatio) {
-            imgRatio = minWidth / actualHeight;
-            actualWidth = round(imgRatio * actualWidth);
-            actualHeight = minWidth;
+            imgRatio = minWidth / actualWidth;
         } else {
-            imgRatio = minHeight / actualWidth;
-            actualHeight = round(imgRatio * actualHeight);
-            actualWidth = minHeight;
+            imgRatio = minHeight / actualHeight;
         }
     }
-    CGRect rect = CGRectMake(0.0, 0.0, floor(actualWidth), floor(actualHeight));
+
+    actualWidth = floor(imgRatio * actualWidth);
+    actualHeight = floor(imgRatio * actualHeight);
+    
+    CGRect rect = CGRectMake(0.0, 0.0, actualWidth, actualHeight);
     UIGraphicsBeginImageContext(rect.size);
     [self drawInRect:rect];
     UIImage *newImage = UIGraphicsGetImageFromCurrentImageContext();

--- a/ios/Classes/UIImage+scale.m
+++ b/ios/Classes/UIImage+scale.m
@@ -12,12 +12,10 @@
     float imgRatio = actualWidth/actualHeight;
     float maxRatio = minWidth/minHeight;
     
-    if(imgRatio != maxRatio) {
-        if(imgRatio < maxRatio) {
-            imgRatio = minWidth / actualWidth;
-        } else {
-            imgRatio = minHeight / actualHeight;
-        }
+    if(imgRatio < maxRatio) {
+        imgRatio = minWidth / actualWidth;
+    } else {
+        imgRatio = minHeight / actualHeight;
     }
 
     actualWidth = floor(imgRatio * actualWidth);


### PR DESCRIPTION
iOS resize logic was completely broken after #85 merged.

- A. Mistakenly shrank excessively and produced image size was smaller one of Android(correct)
  - Fixed by https://github.com/OpenFlutter/flutter_image_compress/commit/0c940af47cfca60e878afd24d765132fbd54127c
- B. If original image aspect ratio and `minWidth/minHeight` is same, it won't be resized
  - Fixed by https://github.com/OpenFlutter/flutter_image_compress/commit/f3e707106ed69e1839a9eb487ca7c89cf180167c

You can check iOS/Android resized log at [example](https://github.com/OpenFlutter/flutter_image_compress/tree/master/example).

For example `CompressFile and rotate 180` was pressed, original log was here:

Android(correct)

```
src width = 4000.0
src height = 2327.0
width scale = 1.7391304
height scale = 1.5513333
scale = 1.5513333
dst width = 2578.4272
dst height = 1500.0
```

iOS(broken dst size)

```
width = 4000
height = 2327
minWidth = 2300
minHeight = 1500
format = 0
scale = 0.38
dst width = 1500.00 // Incorrect
dst height = 873.00 // Incorrect
```


---

For `B` problem, you can check by modifying https://github.com/OpenFlutter/flutter_image_compress/blob/bc8cd9097d6286cef684f21968fbcb6903aa7fa8/example/lib/main.dart#L269-L270 to this(image size is 1036x1024, so aspect ratio is same):

```dart
      minWidth: 518,
      minHeight: 512,
```