### PR TITLE
Handling out of memory error while reading image using handle file

### DIFF
--- a/android/src/main/kotlin/com/example/flutterimagecompress/core/CompressFileHandler.kt
+++ b/android/src/main/kotlin/com/example/flutterimagecompress/core/CompressFileHandler.kt
@@ -25,6 +25,7 @@ class CompressFileHandler(private val call: MethodCall, result: MethodChannel.Re
       val format = args[6] as Int
       val keepExif = args[7] as Boolean
       val inSampleSize = args[8] as Int
+      val numberOfRetries = args[9] as Int
 
       val formatHandler = FormatRegister.findFormat(format)
 
@@ -50,7 +51,7 @@ class CompressFileHandler(private val call: MethodCall, result: MethodChannel.Re
       val targetRotate = rotate + exifRotate
       val outputStream = ByteArrayOutputStream()
       try {
-        formatHandler.handleFile(context, filePath, outputStream, minWidth, minHeight, quality, targetRotate, keepExif, inSampleSize)
+        formatHandler.handleFile(context, filePath, outputStream, minWidth, minHeight, quality, targetRotate, keepExif, inSampleSize,numberOfRetries)
         reply(outputStream.toByteArray())
       } catch (e: Exception) {
         if (FlutterImageCompressPlugin.showLog) e.printStackTrace()
@@ -71,7 +72,6 @@ class CompressFileHandler(private val call: MethodCall, result: MethodChannel.Re
       val targetPath = args[4] as String
       val rotate = args[5] as Int
       val autoCorrectionAngle = args[6] as Boolean
-
       val exifRotate =
               if (autoCorrectionAngle) {
                 val bytes = File(file).readBytes()
@@ -83,7 +83,8 @@ class CompressFileHandler(private val call: MethodCall, result: MethodChannel.Re
 
       val format = args[7] as Int
       val keepExif = args[8] as Boolean
-      val inSampleSize = args[9] as Int
+      val inSampleSize = args[9] as Int      
+      val numberOfRetries = args[10] as Int
 
       val formatHandler = FormatRegister.findFormat(format)
 
@@ -103,7 +104,7 @@ class CompressFileHandler(private val call: MethodCall, result: MethodChannel.Re
       var outputStream: OutputStream? = null
       try {
         outputStream = File(targetPath).outputStream()
-        formatHandler.handleFile(context, file, outputStream, minWidth, minHeight, quality, targetRotate, keepExif, inSampleSize)
+        formatHandler.handleFile(context, file, outputStream, minWidth, minHeight, quality, targetRotate, keepExif, inSampleSize,numberOfRetries)
         reply(targetPath)
       } catch (e: Exception) {
         if (FlutterImageCompressPlugin.showLog) e.printStackTrace()

--- a/android/src/main/kotlin/com/example/flutterimagecompress/handle/FormatHandler.kt
+++ b/android/src/main/kotlin/com/example/flutterimagecompress/handle/FormatHandler.kt
@@ -11,5 +11,5 @@ interface FormatHandler {
 
   fun handleByteArray(context: Context, byteArray: ByteArray, outputStream: OutputStream, minWidth: Int, minHeight: Int, quality: Int, rotate: Int, keepExif: Boolean, inSampleSize: Int)
 
-  fun handleFile(context: Context, path: String, outputStream: OutputStream, minWidth: Int, minHeight: Int, quality: Int, rotate: Int, keepExif: Boolean, inSampleSize: Int)
+  fun handleFile(context: Context, path: String, outputStream: OutputStream, minWidth: Int, minHeight: Int, quality: Int, rotate: Int, keepExif: Boolean, inSampleSize: Int,numberOfRetries:Int)
 }

--- a/android/src/main/kotlin/com/example/flutterimagecompress/handle/common/CommonHandler.kt
+++ b/android/src/main/kotlin/com/example/flutterimagecompress/handle/common/CommonHandler.kt
@@ -111,7 +111,7 @@ class CommonHandler(override val type: Int) : FormatHandler {
       } else {
         outputStream.write(array)
       }
-    }catch (e:OutOfMemoryError){
+    }catch (e:OutOfMemoryError){//handling out of memory error and increase samples size
       System.gc();
       handleFile(context, path, outputStream, minWidth, minHeight, quality, rotate, keepExif, inSampleSize *2);
     }

--- a/android/src/main/kotlin/com/example/flutterimagecompress/handle/common/CommonHandler.kt
+++ b/android/src/main/kotlin/com/example/flutterimagecompress/handle/common/CommonHandler.kt
@@ -86,8 +86,9 @@ class CommonHandler(override val type: Int) : FormatHandler {
   }
 
 
-  override fun handleFile(context: Context, path: String, outputStream: OutputStream, minWidth: Int, minHeight: Int, quality: Int, rotate: Int, keepExif: Boolean, inSampleSize: Int) {
+  override fun handleFile(context: Context, path: String, outputStream: OutputStream, minWidth: Int, minHeight: Int, quality: Int, rotate: Int, keepExif: Boolean, inSampleSize: Int,numberOfRetries:Int) {
     try{
+      if(numberOfRetries <= 0)return;
       val options = BitmapFactory.Options()
       options.inJustDecodeBounds = false
       options.inPreferredConfig = Bitmap.Config.RGB_565
@@ -113,7 +114,7 @@ class CommonHandler(override val type: Int) : FormatHandler {
       }
     }catch (e:OutOfMemoryError){//handling out of memory error and increase samples size
       System.gc();
-      handleFile(context, path, outputStream, minWidth, minHeight, quality, rotate, keepExif, inSampleSize *2);
+      handleFile(context, path, outputStream, minWidth, minHeight, quality, rotate, keepExif, inSampleSize *2,numberOfRetries-1);
     }
   }
 }

--- a/android/src/main/kotlin/com/example/flutterimagecompress/handle/common/CommonHandler.kt
+++ b/android/src/main/kotlin/com/example/flutterimagecompress/handle/common/CommonHandler.kt
@@ -87,28 +87,33 @@ class CommonHandler(override val type: Int) : FormatHandler {
 
 
   override fun handleFile(context: Context, path: String, outputStream: OutputStream, minWidth: Int, minHeight: Int, quality: Int, rotate: Int, keepExif: Boolean, inSampleSize: Int) {
-    val options = BitmapFactory.Options()
-    options.inJustDecodeBounds = false
-    options.inPreferredConfig = Bitmap.Config.RGB_565
-    options.inSampleSize = inSampleSize
-    if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.M) {
-      @Suppress("DEPRECATION")
-      options.inDither = true
-    }
-    val bitmap = BitmapFactory.decodeFile(path, options)
+    try{
+      val options = BitmapFactory.Options()
+      options.inJustDecodeBounds = false
+      options.inPreferredConfig = Bitmap.Config.RGB_565
+      options.inSampleSize = inSampleSize
+      if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.M) {
+        @Suppress("DEPRECATION")
+        options.inDither = true
+      }
+      val bitmap = BitmapFactory.decodeFile(path, options)
 
-    val array = bitmap.compress(minWidth, minHeight, quality, rotate, type)
+      val array = bitmap.compress(minWidth, minHeight, quality, rotate, type)
 
-    if (keepExif && bitmapFormat == Bitmap.CompressFormat.JPEG) {
-      val byteArrayOutputStream = ByteArrayOutputStream()
-      byteArrayOutputStream.write(array)
-      val tmpOutputStream = ExifKeeper(path).writeToOutputStream(
-              context,
-              byteArrayOutputStream
-      )
-      outputStream.write(tmpOutputStream.toByteArray())
-    } else {
-      outputStream.write(array)
+      if (keepExif && bitmapFormat == Bitmap.CompressFormat.JPEG) {
+        val byteArrayOutputStream = ByteArrayOutputStream()
+        byteArrayOutputStream.write(array)
+        val tmpOutputStream = ExifKeeper(path).writeToOutputStream(
+                context,
+                byteArrayOutputStream
+        )
+        outputStream.write(tmpOutputStream.toByteArray())
+      } else {
+        outputStream.write(array)
+      }
+    }catch (e:OutOfMemoryError){
+      System.gc();
+      handleFile(context, path, outputStream, minWidth, minHeight, quality, rotate, keepExif, inSampleSize *2);
     }
   }
 }

--- a/android/src/main/kotlin/com/example/flutterimagecompress/handle/heif/HeifHandler.kt
+++ b/android/src/main/kotlin/com/example/flutterimagecompress/handle/heif/HeifHandler.kt
@@ -82,7 +82,7 @@ class HeifHandler : FormatHandler {
     heifWriter.close()
   }
 
-  override fun handleFile(context: Context, path: String, outputStream: OutputStream, minWidth: Int, minHeight: Int, quality: Int, rotate: Int, keepExif: Boolean, inSampleSize: Int) {
+  override fun handleFile(context: Context, path: String, outputStream: OutputStream, minWidth: Int, minHeight: Int, quality: Int, rotate: Int, keepExif: Boolean, inSampleSize: Int,numberOfRetries:Int) {
     val tmpFile = TmpFileUtil.createTmpFile(context)
     compress(path, minWidth, minHeight, quality, rotate, inSampleSize, tmpFile.absolutePath)
     outputStream.write(tmpFile.readBytes())

--- a/lib/flutter_image_compress.dart
+++ b/lib/flutter_image_compress.dart
@@ -102,11 +102,15 @@ class FlutterImageCompress {
     bool autoCorrectionAngle = true,
     CompressFormat format = CompressFormat.jpeg,
     bool keepExif = false,
+    int numberOfRetries = 5
   }) async {
     assert(
       path != null,
       "A non-null String must be provided to FlutterImageCompress.",
     );
+    if(numberOfRetries == null || numberOfRetries <= 0){
+      throw "numberOfRetries can't be null or less than 0";
+    }
     if (path == null || !File(path).existsSync()) {
       throw "Image file ($path) does not exist.";
     }
@@ -126,6 +130,7 @@ class FlutterImageCompress {
       _convertTypeToInt(format),
       keepExif,
       inSampleSize,
+      numberOfRetries
     ]);
     return result;
   }
@@ -142,11 +147,15 @@ class FlutterImageCompress {
     bool autoCorrectionAngle = true,
     CompressFormat format = CompressFormat.jpeg,
     bool keepExif = false,
+    int numberOfRetries = 5
   }) async {
     assert(
       path != null,
       "A non-null String must be provided to FlutterImageCompress.",
     );
+    if(numberOfRetries == null || numberOfRetries <= 0){
+      throw "numberOfRetries can't be null or less than 0";
+    }
     if (path == null || !File(path).existsSync()) {
       throw "Image file does not exist";
     }
@@ -173,6 +182,7 @@ class FlutterImageCompress {
       _convertTypeToInt(format),
       keepExif,
       inSampleSize,
+      numberOfRetries
     ]);
 
     if (result == null) {


### PR DESCRIPTION
* Added try-catch to catch OutOfMemory Error.
* calling `System.gc()` and increasing sample size before recalling the same method.