### PR TITLE
updated compileSdkVersion  to pass the test

### DIFF
--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 31
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'


### PR DESCRIPTION
BUILD FAILED in 1m 17s
Running Gradle task 'assembleDebug'...                             78.1s

┌─ Flutter Fix ────────────────────────────────────────────────────────────────────────────────────┐
│ [!] Your project requires a higher compileSdkVersion.                                            │
│ Fix this issue by bumping the compileSdkVersion in                                               │
│ /home/runner/work/flutter_image_compress/flutter_image_compress/example/android/app/build.gradle │
│ :                                                                                                │
│ android {                                                                                        │
│   compileSdkVersion 31                                                                           │
│ }                                                                                                │
└──────────────────────────────────────────────────────────────────────────────────────────────────┘
Gradle task assembleDebug failed with exit code 1