### PR TITLE
Android: add namespace for compat with AGP 8.0

### DIFF
--- a/packages/flutter_image_compress_common/android/build.gradle
+++ b/packages/flutter_image_compress_common/android/build.gradle
@@ -24,6 +24,10 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    if (project.android.hasProperty("namespace")) {
+        namespace 'com.fluttercandies.flutter_image_compress'
+    }
+
     compileSdkVersion 31
 
     sourceSets {


### PR DESCRIPTION
Currently, this plugin fails to compile/gradle sync with AGP 8.0.

Add namespace to fix that issue.

### Partially addresses

- **#319** and **#320** — this PR fixes the missing-namespace half of the AGP 8.0 breakage. The reports also involve Kotlin version conflicts (users had to override `ext.kotlin_version` to 2.0.20 or bump gradle to 8.2.2 to fully build); those Kotlin/KGP-side issues remain open and are tracked alongside the broader "Migrate to Built-in Kotlin" work (#362 / #361 / #345 / #326).
