### PR TITLE
Implement toString to CompressError

### DIFF
--- a/packages/flutter_image_compress_platform_interface/lib/src/errors.dart
+++ b/packages/flutter_image_compress_platform_interface/lib/src/errors.dart
@@ -2,4 +2,7 @@ class CompressError extends Error {
   CompressError(this.message);
 
   final String message;
+
+  @override
+  String toString() => 'CompressError: $message';
 }


### PR DESCRIPTION
Hi, thank you for this awesome package!

As a user, I'd like to apply a small improvement to make the error more understandable. `CompressError` doesn't currently have `toString`, so unless a logger or similar explicitly reads the `#message`, the content may be unclear. For example,

```
[ERROR:flutter/runtime/dart_vm_initializer.cc(41)] Unhandled Exception: Instance of 'CompressError'
#0      FlutterImageCompressCommon.compressAndGetFile (package:flutter_image_compress_common/flutter_image_compress_common.dart:167:7)
#1      FlutterImageCompress.compressAndGetFile (package:flutter_image_compress/flutter_image_compress.dart:105:22)
```
After applying this patch.

```
[ERROR:flutter/runtime/dart_vm_initializer.cc(41)] Unhandled Exception: CompressError: numberOfRetries can't be null or less than 0
#0      FlutterImageCompressCommon.compressAndGetFile (package:flutter_image_compress_common/flutter_image_compress_common.dart:167:7)
#1      FlutterImageCompress.compressAndGetFile (package:flutter_image_compress/flutter_image_compress.dart:105:22)
```

Could you please consider if it can be merged?

### Partially addresses

- **#252** — this PR makes `CompressError` at least readable in unhandled-exception logs. It does not add structured error fields (code / status) that #252 also asks for, so the underlying feature request stays open.
