### PR TITLE
Fix iOS 17 compatibility

### DIFF
--- a/packages/flutter_image_compress_common/ios/Classes/UIImage+scale.m
+++ b/packages/flutter_image_compress_common/ios/Classes/UIImage+scale.m
@@ -24,10 +24,18 @@
     actualHeight = floor(scaleRatio * actualHeight);
     
     CGRect rect = CGRectMake(0.0, 0.0, actualWidth, actualHeight);
-    UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize:rect.size];
-    UIImage *newImage = [renderer imageWithActions:^(UIGraphicsImageRendererContext * _Nonnull context) {
+    UIImage *newImage;
+    if (@available(iOS 10.0, *)) {
+        UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize:rect.size];
+        newImage = [renderer imageWithActions:^(UIGraphicsImageRendererContext * _Nonnull context) {
+            [self drawInRect:rect];
+        }];
+    } else {
+        UIGraphicsBeginImageContext(rect.size);
         [self drawInRect:rect];
-    }];
+        newImage = UIGraphicsGetImageFromCurrentImageContext();
+        UIGraphicsEndImageContext();
+    }
     
     if([ImageCompressPlugin showLog]){
         NSLog(@"scale = %.2f", scaleRatio);
@@ -53,21 +61,41 @@
     rotatedViewBox.transform = t;
     CGSize rotatedSize = rotatedViewBox.frame.size;
 
-    UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize:rotatedSize];
-    UIImage *newImage = [renderer imageWithActions:^(UIGraphicsImageRendererContext * _Nonnull context) {
-        CGContextRef bitmap = context.CGContext;
-        
+    UIImage *newImage;
+    if (@available(iOS 10.0, *)) {
+        UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize:rotatedSize];
+        newImage = [renderer imageWithActions:^(UIGraphicsImageRendererContext * _Nonnull context) {
+            CGContextRef bitmap = context.CGContext;
+
+            // Move the origin to the middle of the image so we will rotate and scale around the center.
+            CGContextTranslateCTM(bitmap, rotatedSize.width/2, rotatedSize.height/2);
+
+            // Rotate the image context
+            CGContextRotateCTM(bitmap, (degrees * M_PI / 180));
+
+            // Now, draw the rotated/scaled image into the context
+            CGContextScaleCTM(bitmap, 1.0, -1.0);
+            CGContextDrawImage(bitmap, CGRectMake(-oldImage.size.width / 2, -oldImage.size.height / 2, oldImage.size.width, oldImage.size.height), [oldImage CGImage]);
+        }];
+    } else {
+        // Create the bitmap context
+        UIGraphicsBeginImageContext(rotatedSize);
+        CGContextRef bitmap = UIGraphicsGetCurrentContext();
+
         // Move the origin to the middle of the image so we will rotate and scale around the center.
         CGContextTranslateCTM(bitmap, rotatedSize.width/2, rotatedSize.height/2);
-        
+
         // Rotate the image context
         CGContextRotateCTM(bitmap, (degrees * M_PI / 180));
-        
+
         // Now, draw the rotated/scaled image into the context
         CGContextScaleCTM(bitmap, 1.0, -1.0);
         CGContextDrawImage(bitmap, CGRectMake(-oldImage.size.width / 2, -oldImage.size.height / 2, oldImage.size.width, oldImage.size.height), [oldImage CGImage]);
-    }];
-    
+
+        newImage = UIGraphicsGetImageFromCurrentImageContext();
+        UIGraphicsEndImageContext();
+    }
+
     return newImage;
 }
 

--- a/packages/flutter_image_compress_common/ios/Classes/UIImage+scale.m
+++ b/packages/flutter_image_compress_common/ios/Classes/UIImage+scale.m
@@ -26,8 +26,15 @@
     CGRect rect = CGRectMake(0.0, 0.0, actualWidth, actualHeight);
     UIImage *newImage;
     if (@available(iOS 10.0, *)) {
+        // Match the legacy UIGraphicsBeginImageContext behavior:
+        //   - scale = 1.0 keeps output in logical pixels (renderer default is device screen scale, e.g. 2x/3x).
+        //   - preferredRange = Standard keeps output in sRGB (renderer default is automatic, which produces
+        //     P3/extended-range bitmaps on wide-gamut devices and can inflate compressed file sizes).
         UIGraphicsImageRendererFormat *format = [[UIGraphicsImageRendererFormat alloc] init];
         format.scale = 1.0;
+        if (@available(iOS 12.0, *)) {
+            format.preferredRange = UIGraphicsImageRendererFormatRangeStandard;
+        }
         UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize:rect.size format:format];
         newImage = [renderer imageWithActions:^(UIGraphicsImageRendererContext * _Nonnull context) {
             [self drawInRect:rect];
@@ -65,8 +72,12 @@
 
     UIImage *newImage;
     if (@available(iOS 10.0, *)) {
+        // See scaleWithMinWidth:minHeight: for why scale and preferredRange are pinned.
         UIGraphicsImageRendererFormat *format = [[UIGraphicsImageRendererFormat alloc] init];
         format.scale = 1.0;
+        if (@available(iOS 12.0, *)) {
+            format.preferredRange = UIGraphicsImageRendererFormatRangeStandard;
+        }
         UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize:rotatedSize format:format];
         newImage = [renderer imageWithActions:^(UIGraphicsImageRendererContext * _Nonnull context) {
             CGContextRef bitmap = context.CGContext;

--- a/packages/flutter_image_compress_common/ios/Classes/UIImage+scale.m
+++ b/packages/flutter_image_compress_common/ios/Classes/UIImage+scale.m
@@ -26,7 +26,9 @@
     CGRect rect = CGRectMake(0.0, 0.0, actualWidth, actualHeight);
     UIImage *newImage;
     if (@available(iOS 10.0, *)) {
-        UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize:rect.size];
+        UIGraphicsImageRendererFormat *format = [[UIGraphicsImageRendererFormat alloc] init];
+        format.scale = 1.0;
+        UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize:rect.size format:format];
         newImage = [renderer imageWithActions:^(UIGraphicsImageRendererContext * _Nonnull context) {
             [self drawInRect:rect];
         }];
@@ -63,7 +65,9 @@
 
     UIImage *newImage;
     if (@available(iOS 10.0, *)) {
-        UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize:rotatedSize];
+        UIGraphicsImageRendererFormat *format = [[UIGraphicsImageRendererFormat alloc] init];
+        format.scale = 1.0;
+        UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize:rotatedSize format:format];
         newImage = [renderer imageWithActions:^(UIGraphicsImageRendererContext * _Nonnull context) {
             CGContextRef bitmap = context.CGContext;
 


### PR DESCRIPTION
Fixes #310 — replace deprecated `UIGraphicsBeginImageContext` with `UIGraphicsImageRenderer` on the scale path in `UIImage+scale.m`.

### Partially addresses

- **#353** — only the `scaleWithMinWidth:minHeight:` path was rewritten. The `imageRotatedByDegrees:` path in the same file still allocates a `UIView` on the caller's (background) thread to compute the rotated bounding box, which is the exact Main Thread Checker violation in #353's stack trace. A follow-up should replace the `UIView` bounding-box trick with `CGRectApplyAffineTransform`.
