### PR TITLE
Add Swift Package Manager support for iOS platform

### DIFF
--- a/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Package.swift
+++ b/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Package.swift
@@ -1,0 +1,28 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "flutter_image_compress_common",
+    platforms: [
+        .iOS("12.0")
+    ],
+    products: [
+        .library(name: "flutter-image-compress-common", targets: ["flutter_image_compress_common"])
+    ],
+    dependencies: [
+        .package(url: "https://github.com/Mantle/Mantle.git", from: "2.2.0"),
+        .package(url: "https://github.com/SDWebImage/SDWebImage.git", from: "5.19.0"),
+        .package(url: "https://github.com/SDWebImage/SDWebImageWebPCoder.git", from: "0.14.0"),
+    ],
+    targets: [
+        .target(
+            name: "flutter_image_compress_common",
+            dependencies: [
+                .product(name: "Mantle", package: "Mantle"),
+                .product(name: "SDWebImage", package: "SDWebImage"),
+                .product(name: "SDWebImageWebPCoder", package: "SDWebImageWebPCoder"),
+            ],
+            publicHeadersPath: ""
+        )
+    ]
+)

--- a/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/CompressFileHandler.h
+++ b/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/CompressFileHandler.h
@@ -1,0 +1,12 @@
+//
+// Created by cjl on 2018/9/8.
+//
+
+#import <Foundation/Foundation.h>
+#import <Flutter/Flutter.h>
+
+@interface CompressFileHandler : NSObject
+- (void)handleMethodCall:(FlutterMethodCall *)call result:(FlutterResult)result;
+
+- (void)handleCompressFileToFile:(FlutterMethodCall *)call result:(FlutterResult)result;
+@end

--- a/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/CompressFileHandler.m
+++ b/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/CompressFileHandler.m
@@ -1,0 +1,148 @@
+//
+// Created by cjl on 2018/9/8.
+//
+
+#import "CompressFileHandler.h"
+#import "CompressHandler.h"
+#import "SYMetadata.h"
+@import SDWebImageWebPCoder;
+@import SDWebImage;
+#import <UIKit/UIKit.h>
+
+@implementation CompressFileHandler {
+
+}
+- (void)handleMethodCall:(FlutterMethodCall *)call result:(FlutterResult)result {
+
+    NSArray *args = call.arguments;
+    NSString *path = args[0];
+    int minWidth = [args[1] intValue];
+    int minHeight = [args[2] intValue];
+    int quality = [args[3] intValue];
+    int rotate = [args[4] intValue];
+
+    int formatType = [args[6] intValue];
+    BOOL keepExif = [args[7] boolValue];
+
+    
+    UIImage *img;
+    
+    NSURL *imageUrl = [NSURL fileURLWithPath:path];
+    NSData *nsdata = [NSData dataWithContentsOfURL:imageUrl];
+    
+    NSString *imageType = [self mimeTypeByGuessingFromData:nsdata];
+    
+    //  NSLog(@" nsdata length: %@", imageType);
+    
+    SDImageWebPCoder *webPCoder = [SDImageWebPCoder sharedCoder];
+    [[SDImageCodersManager sharedManager] addCoder:webPCoder];
+    
+    if([imageType  isEqual: @"image/webp"]) {
+    img = [[SDImageWebPCoder sharedCoder] decodedImageWithData:nsdata options:nil];
+    } else {
+        img = [UIImage imageWithData:nsdata];
+    }
+
+
+    NSData *data = [CompressHandler compressWithUIImage:img minWidth:minWidth minHeight:minHeight quality:quality rotate:rotate format:formatType];
+
+    if (keepExif) {
+        SYMetadata *metadata = [SYMetadata metadataWithFileURL:[NSURL fileURLWithPath:path]];
+        metadata.orientation = @0;
+        data = [SYMetadata dataWithImageData:data andMetadata:metadata];
+    }
+
+    result([FlutterStandardTypedData typedDataWithBytes:data]);
+}
+
+- (void)handleCompressFileToFile:(FlutterMethodCall *)call result:(FlutterResult)result {
+    NSArray *args = call.arguments;
+    NSString *path = args[0];
+    int minWidth = [args[1] intValue];
+    int minHeight = [args[2] intValue];
+    int quality = [args[3] intValue];
+    NSString *targetPath = args[4];
+    int rotate = [args[5] intValue];
+
+    int formatType = [args[7] intValue];
+    BOOL keepExif = [args[8] boolValue];
+
+    
+    UIImage *img;
+    
+    NSURL *imageUrl = [NSURL fileURLWithPath:path];
+    NSData *nsdata = [NSData dataWithContentsOfURL:imageUrl];
+    
+    NSString *imageType = [self mimeTypeByGuessingFromData:nsdata];
+    
+    //  NSLog(@" nsdata length: %@", imageType);
+    
+    SDImageWebPCoder *webPCoder = [SDImageWebPCoder sharedCoder];
+    [[SDImageCodersManager sharedManager] addCoder:webPCoder];
+    
+    if([imageType  isEqual: @"image/webp"]) {
+    img = [[SDImageWebPCoder sharedCoder] decodedImageWithData:nsdata options:nil];
+    } else {
+        img = [UIImage imageWithData:nsdata];
+    }
+    
+    NSData *data = [CompressHandler compressDataWithUIImage:img minWidth:minWidth minHeight:minHeight quality:quality rotate:rotate format:formatType];
+
+    if (keepExif) {
+        SYMetadata *metadata = [SYMetadata metadataWithFileURL:[NSURL fileURLWithPath:path]];
+        metadata.orientation = @0;
+        data = [SYMetadata dataWithImageData:data andMetadata:metadata];
+    }
+
+    [data writeToURL:[[NSURL alloc] initFileURLWithPath:targetPath] atomically:YES];
+
+    result(targetPath);
+}
+
+
+- (NSString *)mimeTypeByGuessingFromData:(NSData *)data {
+
+    char bytes[12] = {0};
+    [data getBytes:&bytes length:12];
+
+    const char bmp[2] = {'B', 'M'};
+    const char gif[3] = {'G', 'I', 'F'};
+    const char swf[3] = {'F', 'W', 'S'};
+    const char swc[3] = {'C', 'W', 'S'};
+    const char jpg[3] = {0xff, 0xd8, 0xff};
+    const char psd[4] = {'8', 'B', 'P', 'S'};
+    const char iff[4] = {'F', 'O', 'R', 'M'};
+    const char webp[4] = {'R', 'I', 'F', 'F'};
+    const char ico[4] = {0x00, 0x00, 0x01, 0x00};
+    const char tif_ii[4] = {'I','I', 0x2A, 0x00};
+    const char tif_mm[4] = {'M','M', 0x00, 0x2A};
+    const char png[8] = {0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a};
+    const char jp2[12] = {0x00, 0x00, 0x00, 0x0c, 0x6a, 0x50, 0x20, 0x20, 0x0d, 0x0a, 0x87, 0x0a};
+
+
+    if (!memcmp(bytes, bmp, 2)) {
+        return @"image/x-ms-bmp";
+    } else if (!memcmp(bytes, gif, 3)) {
+        return @"image/gif";
+    } else if (!memcmp(bytes, jpg, 3)) {
+        return @"image/jpeg";
+    } else if (!memcmp(bytes, psd, 4)) {
+        return @"image/psd";
+    } else if (!memcmp(bytes, iff, 4)) {
+        return @"image/iff";
+    } else if (!memcmp(bytes, webp, 4)) {
+        return @"image/webp";
+    } else if (!memcmp(bytes, ico, 4)) {
+        return @"image/vnd.microsoft.icon";
+    } else if (!memcmp(bytes, tif_ii, 4) || !memcmp(bytes, tif_mm, 4)) {
+        return @"image/tiff";
+    } else if (!memcmp(bytes, png, 8)) {
+        return @"image/png";
+    } else if (!memcmp(bytes, jp2, 12)) {
+        return @"image/jp2";
+    }
+
+    return @"application/octet-stream"; // default type
+
+}
+@end

--- a/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/CompressHandler.h
+++ b/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/CompressHandler.h
@@ -1,0 +1,18 @@
+//
+// Created by cjl on 2018/9/8.
+//
+
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
+
+@interface CompressHandler : NSObject
++ (NSData *)compressWithData:(NSData *)data minWidth:(int)minWidth minHeight:(int)minHeight quality:(int)quality
+                      rotate:(int)rotate format:(int)format;
+
++ (NSData *)compressWithUIImage:(UIImage *)image minWidth:(int)minWidth minHeight:(int)minHeight quality:(int)quality
+                         rotate:(int)rotate format:(int)format;
+
++ (NSData *)compressDataWithUIImage:(UIImage *)image minWidth:(int)minWidth minHeight:(int)minHeight
+                            quality:(int)quality rotate:(int)rotate format:(int)format;
+@end

--- a/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/CompressHandler.m
+++ b/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/CompressHandler.m
@@ -1,0 +1,93 @@
+//
+// Created by cjl on 2018/9/8.
+//
+
+#import "CompressHandler.h"
+#import "UIImage+scale.h"
+#import "ImageCompressPlugin.h"
+@import SDWebImageWebPCoder;
+#import <UIKit/UIKit.h>
+
+@implementation CompressHandler {
+
+}
+
++ (NSData *)compressWithData:(NSData *)data minWidth:(int)minWidth minHeight:(int)minHeight quality:(int)quality
+                      rotate:(int)rotate format:(int)format {
+    UIImage *img = [self isWebP:data] ? [UIImage sd_imageWithWebPData:data] : [[UIImage alloc] initWithData:data];
+    return [CompressHandler compressWithUIImage:img minWidth:minWidth minHeight:minHeight quality:quality rotate:rotate format:format];
+}
+
++ (NSData *)compressWithUIImage:(UIImage *)image minWidth:(int)minWidth minHeight:(int)minHeight quality:(int)quality
+                         rotate:(int)rotate format:(int)format {
+    if([ImageCompressPlugin showLog]){
+        NSLog(@"width = %.0f",[image size].width);
+        NSLog(@"height = %.0f",[image size].height);
+        NSLog(@"minWidth = %d",minWidth);
+        NSLog(@"minHeight = %d",minHeight);
+        NSLog(@"format = %d", format);
+    }
+
+    image = [image scaleWithMinWidth:minWidth minHeight:minHeight];
+    if(rotate % 360 != 0){
+        image = [image rotate: rotate];
+    }
+    NSData *resultData = [self compressDataWithImage:image quality:quality format:format];
+
+    return resultData;
+}
+
+
++ (NSData *)compressDataWithUIImage:(UIImage *)image minWidth:(int)minWidth minHeight:(int)minHeight
+                            quality:(int)quality rotate:(int)rotate format:(int)format {
+    image = [image scaleWithMinWidth:minWidth minHeight:minHeight];
+    if(rotate % 360 != 0){
+        image = [image rotate: rotate];
+    }
+    return [self compressDataWithImage:image quality:quality format:format];
+}
+
++ (NSData *)compressDataWithImage:(UIImage *)image quality:(float)quality format:(int)format  {
+    NSData *data;
+    if (format == 2) { // heic
+        CIImage *ciImage = [CIImage imageWithCGImage:image.CGImage];
+        CIContext *ciContext = [[CIContext alloc]initWithOptions:nil];
+        NSString *tmpDir = NSTemporaryDirectory();
+        double time = [[NSDate alloc]init].timeIntervalSince1970;
+        NSString *target = [NSString stringWithFormat:@"%@%.0f.heic",tmpDir, time * 1000];
+        NSURL *url = [NSURL fileURLWithPath:target];
+        
+        NSMutableDictionary *options = [NSMutableDictionary new];
+        NSString *qualityKey = (__bridge NSString *)kCGImageDestinationLossyCompressionQuality;
+//        CIImageRepresentationOption
+        [options setObject:@(quality / 100) forKey: qualityKey];
+        
+        if (@available(iOS 11.0, *)) {
+            [ciContext writeHEIFRepresentationOfImage:ciImage toURL:url format: kCIFormatARGB8 colorSpace: ciImage.colorSpace options:options error:nil];
+            data = [NSData dataWithContentsOfURL:url];
+        } else {
+            // Fallback on earlier versions
+            data = nil;
+        }
+    } else if(format == 3){ // webp
+        SDImageCoderOptions *option = @{SDImageCoderEncodeCompressionQuality: @(quality / 100)};
+        data = [[SDImageWebPCoder sharedCoder]encodedDataWithImage:image format:SDImageFormatWebP options:option];
+    } else if(format == 1){ // png
+        data = UIImagePNGRepresentation(image);
+    }else { // 0 or other is jpeg
+        data = UIImageJPEGRepresentation(image, (CGFloat) quality / 100);
+    }
+
+    return data;
+}
+
++ (BOOL)isWebP:(NSData *)data {
+    if (data.length < 12) return false;
+
+    NSData *riff = [data subdataWithRange:NSMakeRange(8, 4)];
+    NSString* format = [[NSString alloc] initWithData:riff encoding:(NSASCIIStringEncoding)];
+
+    return [format isEqualToString:@"WEBP"];
+}
+
+@end

--- a/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/CompressListHandler.h
+++ b/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/CompressListHandler.h
@@ -1,0 +1,13 @@
+//
+//  CompressListHandler.h
+//  flutter_image_compress
+//
+//  Created by cjl on 2018/9/8.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface CompressListHandler : NSObject
+
+- (void)handleMethodCall:(FlutterMethodCall *)call result:(FlutterResult)result;
+@end

--- a/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/CompressListHandler.m
+++ b/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/CompressListHandler.m
@@ -1,0 +1,44 @@
+//
+//  CompressListHandler.m
+//  flutter_image_compress
+//
+//  Created by cjl on 2018/9/8.
+//
+
+#import <Flutter/Flutter.h>
+#import "CompressListHandler.h"
+#import "CompressHandler.h"
+#import "SYMetadata.h"
+
+@implementation CompressListHandler
+
+- (void)handleMethodCall:(FlutterMethodCall *)call result:(FlutterResult)result {
+    NSArray *args = call.arguments;
+    FlutterStandardTypedData *list = args[0];
+    int minWidth = [args[1] intValue];
+    int minHeight = [args[2] intValue];
+    int quality = [args[3] intValue];
+    int rotate = [args[4] intValue];
+    int formatType = [args[6] intValue];
+
+    BOOL keepExif = [args[7] boolValue];
+
+    NSData *data = [list data];
+    NSData *compressedData = [CompressHandler compressWithData:data minWidth:minWidth minHeight:minHeight quality:quality rotate:rotate format:formatType];
+    
+    if (compressedData == nil) {
+        result(nil);
+        return;
+    }
+    
+    if (keepExif) {
+        SYMetadata *metadata = [SYMetadata metadataWithImageData:data];
+        metadata.orientation = @0;
+        compressedData = [SYMetadata dataWithImageData:compressedData andMetadata:metadata];
+    }
+
+    result([FlutterStandardTypedData typedDataWithBytes:compressedData]);
+}
+
+
+@end

--- a/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/ImageCompressPlugin.h
+++ b/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/ImageCompressPlugin.h
@@ -1,0 +1,7 @@
+#import <Flutter/Flutter.h>
+
+@interface ImageCompressPlugin : NSObject<FlutterPlugin>
+
++(BOOL) showLog;
+
+@end

--- a/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/ImageCompressPlugin.m
+++ b/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/ImageCompressPlugin.m
@@ -1,0 +1,53 @@
+#import "ImageCompressPlugin.h"
+#import "CompressListHandler.h"
+#import "CompressFileHandler.h"
+#import <UIKit/UIKit.h>
+
+BOOL showLog = false;
+
+@implementation ImageCompressPlugin
+static dispatch_queue_t serial_queue;
+
++ (void)registerWithRegistrar:(NSObject <FlutterPluginRegistrar> *)registrar {
+    serial_queue = dispatch_get_global_queue(0, 0);
+
+    FlutterMethodChannel *channel = [FlutterMethodChannel
+            methodChannelWithName:@"flutter_image_compress"
+                  binaryMessenger:[registrar messenger]];
+    ImageCompressPlugin *instance = [[ImageCompressPlugin alloc] init];
+    [registrar addMethodCallDelegate:instance channel:channel];
+}
+
+- (void)handleMethodCall:(FlutterMethodCall *)call result:(FlutterResult)result {
+    dispatch_async(serial_queue, ^{
+        if ([call.method isEqualToString:@"compressWithList"]) {
+            CompressListHandler *handler = [[CompressListHandler alloc] init];
+            [handler handleMethodCall:call result:result];
+        } else if ([@"compressWithFile" isEqualToString:call.method]) {
+            CompressFileHandler *handler = [[CompressFileHandler alloc] init];
+            [handler handleMethodCall:call result:result];
+        } else if ([@"compressWithFileAndGetFile" isEqualToString:call.method]) {
+            CompressFileHandler *handler = [[CompressFileHandler alloc] init];
+            [handler handleCompressFileToFile:call result:result];
+        } else if ([@"showLog" isEqualToString:call.method]) {
+            [self setShowLog:[call arguments]];
+            result(@1);
+        } else if([@"getSystemVersion" isEqualToString:call.method]) {
+            NSString *systemVersion = [[UIDevice currentDevice] systemVersion];
+            result(systemVersion);
+        } else {
+            result(FlutterMethodNotImplemented);
+        }
+    });
+
+}
+
++ (BOOL)showLog{
+    return showLog;
+}
+
+- (void)setShowLog:(BOOL)log{
+    showLog = log;
+}
+
+@end

--- a/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/NSDictionary+SY.h
+++ b/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/NSDictionary+SY.h
@@ -1,0 +1,19 @@
+//
+//  NSDictionary+SY.h
+//  SYPictureMetadataExample
+//
+//  Created by Stanislas Chevallier on 03/02/2017.
+//  Copyright © 2017 Syan. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface NSDictionary (SY)
+
++ (NSDictionary *)sy_differencesFrom:(NSDictionary *)dictionaryOld
+                                  to:(NSDictionary *)dictionaryNew
+                 includeValuesInDiff:(BOOL)includeValuesInDiff;
+
+- (NSArray <NSString *> *)sy_allKeypaths;
+
+@end

--- a/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/NSDictionary+SY.m
+++ b/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/NSDictionary+SY.m
@@ -1,0 +1,95 @@
+//
+//  NSDictionary+SY.m
+//  SYPictureMetadataExample
+//
+//  Created by Stanislas Chevallier on 03/02/2017.
+//  Copyright © 2017 Syan. All rights reserved.
+//
+
+#import "NSDictionary+SY.h"
+
+@implementation NSDictionary (SY)
+
++ (NSDictionary *)sy_differencesFrom:(NSDictionary *)dictionaryOld
+                                  to:(NSDictionary *)dictionaryNew
+                 includeValuesInDiff:(BOOL)includeValuesInDiff;
+{
+    NSString *formatAdded    = (includeValuesInDiff ? @"Added: %@"          : @"Added"  );
+    NSString *formatUpdated  = (includeValuesInDiff ? @"Updated: %@ -> %@"  : @"Updated");
+    NSString *formatRemoved  = (includeValuesInDiff ? @"Removed: %@"        : @"Removed");
+    
+    NSMutableSet *allKeys = [NSMutableSet set];
+    [allKeys addObjectsFromArray:dictionaryOld.allKeys];
+    [allKeys addObjectsFromArray:dictionaryNew.allKeys];
+    
+    NSMutableDictionary *diffs = [[NSMutableDictionary alloc] init];
+    for (id key in allKeys)
+    {
+        id valueOld = dictionaryOld[key];
+        id valueNew = dictionaryNew[key];
+        
+        if (valueOld && valueNew && [valueOld isEqual:valueNew])
+            continue;
+        
+        BOOL oldIsNilOrDic = !valueOld || [valueOld isKindOfClass:[NSDictionary class]];
+        BOOL newIsNilOrDic = !valueNew || [valueNew isKindOfClass:[NSDictionary class]];
+        
+        if (oldIsNilOrDic && newIsNilOrDic)
+        {
+            NSDictionary *subDiffs = [self sy_differencesFrom:valueOld
+                                                           to:valueNew
+                                          includeValuesInDiff:includeValuesInDiff];
+            [diffs setObject:subDiffs forKey:key];
+            continue;
+        }
+        
+        NSString *valueOldString = [valueOld description];
+        NSString *valueNewString = [valueNew description];
+        
+        if ([valueOld isKindOfClass:[NSArray class]])
+            valueOldString = [valueOld componentsJoinedByString:@", "];
+        if ([valueNew isKindOfClass:[NSArray class]])
+            valueNewString = [valueNew componentsJoinedByString:@", "];
+        
+        if ( valueOld && !valueNew)
+        {
+            [diffs setObject:[NSString stringWithFormat:formatRemoved, valueOldString]
+                      forKey:key];
+            continue;
+        }
+        
+        if (!valueOld &&  valueNew)
+        {
+            [diffs setObject:[NSString stringWithFormat:formatAdded, valueNewString]
+                      forKey:key];
+            continue;
+        }
+        
+        [diffs setObject:[NSString stringWithFormat:formatUpdated, valueOldString, valueNewString]
+                  forKey:key];
+    }
+    
+    return [diffs copy];
+}
+
+- (NSArray <NSString *> *)sy_allKeypaths
+{
+    NSMutableArray <NSString *> *keypaths = [NSMutableArray array];
+    
+    for (id key in self.allKeys)
+    {
+        NSString *keyString = [key description];
+        [keypaths addObject:keyString];
+        
+        id value = self[key];
+        if ([value isKindOfClass:[NSDictionary class]])
+        {
+            for (NSString *subKeypath in [(NSDictionary *)value sy_allKeypaths])
+                [keypaths addObject:[@[keyString, subKeypath] componentsJoinedByString:@"."]];
+        }
+    }
+    
+    return [keypaths copy];
+}
+
+@end

--- a/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadata.h
+++ b/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadata.h
@@ -1,0 +1,86 @@
+//
+//  SYMetadata.h
+//  SYPictureMetadataExample
+//
+//  Created by Stan Chevallier on 12/13/12.
+//  Copyright (c) 2012 Syan. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "SYMetadataTIFF.h"
+#import "SYMetadataGIF.h"
+#import "SYMetadataJFIF.h"
+#import "SYMetadataExif.h"
+#import "SYMetadataPNG.h"
+#import "SYMetadataIPTC.h"
+#import "SYMetadataGPS.h"
+#import "SYMetadataRaw.h"
+#import "SYMetadataCIFF.h"
+#import "SYMetadataMakerCanon.h"
+#import "SYMetadataMakerNikon.h"
+#import "SYMetadataMakerMinolta.h"
+#import "SYMetadataMakerFuji.h"
+#import "SYMetadataMakerOlympus.h"
+#import "SYMetadataMakerPentax.h"
+#import "SYMetadata8BIM.h"
+#import "SYMetadataDNG.h"
+#import "SYMetadataExifAux.h"
+
+// http://www.sno.phy.queensu.ca/~phil/exiftool/TagNames/index.html
+// http://www.exiv2.org/tags.html
+
+@class ALAsset;
+
+@interface SYMetadata : SYMetadataBase
+
+@property SYMETADATA_PROPERTY_COPY NSDictionary *originalDictionary;
+
+@property SYMETADATA_PROPERTY_STRONG SYMetadataTIFF          *metadataTIFF;
+@property SYMETADATA_PROPERTY_STRONG SYMetadataExif          *metadataExif;
+@property SYMETADATA_PROPERTY_STRONG SYMetadataGIF           *metadataGIF;
+@property SYMETADATA_PROPERTY_STRONG SYMetadataJFIF          *metadataJFIF;
+@property SYMETADATA_PROPERTY_STRONG SYMetadataPNG           *metadataPNG;
+@property SYMETADATA_PROPERTY_STRONG SYMetadataIPTC          *metadataIPTC;
+@property SYMETADATA_PROPERTY_STRONG SYMetadataGPS           *metadataGPS;
+@property SYMETADATA_PROPERTY_STRONG SYMetadataRaw           *metadataRaw;
+@property SYMETADATA_PROPERTY_STRONG SYMetadataCIFF          *metadataCIFF;
+@property SYMETADATA_PROPERTY_STRONG SYMetadataMakerCanon    *metadataMakerCanon;
+@property SYMETADATA_PROPERTY_STRONG SYMetadataMakerNikon    *metadataMakerNikon;
+@property SYMETADATA_PROPERTY_STRONG SYMetadataMakerMinolta  *metadataMakerMinolta;
+@property SYMETADATA_PROPERTY_STRONG SYMetadataMakerFuji     *metadataMakerFuji;
+@property SYMETADATA_PROPERTY_STRONG SYMetadataMakerOlympus  *metadataMakerOlympus;
+@property SYMETADATA_PROPERTY_STRONG SYMetadataMakerPentax   *metadataMakerPentax;
+@property SYMETADATA_PROPERTY_STRONG SYMetadata8BIM          *metadata8BIM;
+@property SYMETADATA_PROPERTY_STRONG SYMetadataDNG           *metadataDNG;
+@property SYMETADATA_PROPERTY_STRONG SYMetadataExifAux       *metadataExifAux;
+
+// we don't know how to parse those, so we juste give access to them
+@property SYMETADATA_PROPERTY_COPY NSDictionary   *metadataApple;
+@property SYMETADATA_PROPERTY_COPY NSDictionary   *metadataPictureStyle;
+
+@property (nonatomic, copy, readonly)   NSNumber  *fileSize;
+@property (nonatomic, copy, readonly)   NSNumber  *pixelHeight;
+@property (nonatomic, copy, readonly)   NSNumber  *pixelWidth;
+@property (nonatomic, copy, readonly)   NSNumber  *dpiHeight;
+@property (nonatomic, copy, readonly)   NSNumber  *dpiWidth;
+@property (nonatomic, copy, readonly)   NSNumber  *depth;
+@property SYMETADATA_PROPERTY_COPY      NSNumber  *orientation;
+@property (nonatomic, copy, readonly)   NSNumber  *isFloat;
+@property (nonatomic, copy, readonly)   NSNumber  *isIndexed;
+@property (nonatomic, copy, readonly)   NSNumber  *hasAlpha;
+@property (nonatomic, copy, readonly)   NSString  *colorModel;
+@property (nonatomic, copy, readonly)   NSString  *profileName;
+
++ (instancetype)metadataWithDictionary:(NSDictionary *)dictionary;
++ (instancetype)metadataWithAsset:(ALAsset *)asset __TVOS_PROHIBITED;
++ (instancetype)metadataWithAssetURL:(NSURL *)assetURL __TVOS_PROHIBITED;
++ (instancetype)metadataWithFileURL:(NSURL *)fileURL;
++ (instancetype)metadataWithImageData:(NSData *)imageData;
+
++ (NSDictionary *)dictionaryWithAssetURL:(NSURL *)assetURL __TVOS_PROHIBITED;
+
++ (NSData *)dataWithImageData:(NSData *)imageData andMetadata:(SYMetadata *)metadata;
+
+- (NSDictionary *)differencesFromOriginalMetadataToModel;
+
+@end

--- a/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadata.m
+++ b/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadata.m
@@ -1,0 +1,265 @@
+//
+//  SYMetadata.m
+//  SYPictureMetadataExample
+//
+//  Created by Stan Chevallier on 12/13/12.
+//  Copyright (c) 2012 Syan. All rights reserved.
+//
+
+#import <ImageIO/ImageIO.h>
+#import "SYMetadata.h"
+#import "NSDictionary+SY.h"
+
+#if !TARGET_OS_TV
+#import <AssetsLibrary/AssetsLibrary.h>
+#endif
+
+#define SYKeyForMetadata(name)          NSStringFromSelector(@selector(metadata##name))
+#define SYDictionaryForMetadata(name)   SYPaste(SYPaste(kCGImageProperty,name),Dictionary)
+#define SYClassForMetadata(name)        SYPaste(SYMetadata,name)
+#define SYMappingPptyToClass(name)      SYKeyForMetadata(name):SYClassForMetadata(name).class
+#define SYMappingPptyToKeyPath(name)    SYKeyForMetadata(name):(__bridge NSString *)SYDictionaryForMetadata(name)
+
+@interface SYMetadata (Private)
+- (void)refresh:(BOOL)force;
+@end
+
+@implementation SYMetadata
+
+#pragma mark - Initialization
+
++ (instancetype)metadataWithDictionary:(NSDictionary *)dictionary
+{
+    if (!dictionary)
+        return nil;
+    
+    NSError *error;
+    
+    SYMetadata *instance = [MTLJSONAdapter modelOfClass:self.class fromJSONDictionary:dictionary error:&error];
+    
+    if (instance)
+        instance->_originalDictionary = dictionary;
+        
+    if (error)
+        NSLog(@"--> Error creating %@ object: %@", NSStringFromClass(self.class), error);
+    
+    return instance;
+}
+
++ (instancetype)metadataWithAsset:(ALAsset *)asset
+{
+#if !TARGET_OS_TV
+    ALAssetRepresentation *representation = [asset defaultRepresentation];
+    return [self metadataWithDictionary:[representation metadata]];
+#else
+    return nil;
+#endif
+}
+
++ (instancetype)metadataWithAssetURL:(NSURL *)assetURL
+{
+    NSDictionary *dictionary = [self dictionaryWithAssetURL:assetURL];
+    return [self metadataWithDictionary:dictionary];
+}
+
++ (instancetype)metadataWithFileURL:(NSURL *)fileURL
+{
+    if (!fileURL)
+        return nil;
+    
+    CGImageSourceRef source = CGImageSourceCreateWithURL((__bridge CFURLRef)fileURL, NULL);
+    if (source == NULL)
+        return nil;
+    
+    NSDictionary *dictionary;
+    
+    NSDictionary *options = @{(NSString *)kCGImageSourceShouldCache:@(NO)};
+    CFDictionaryRef properties = CGImageSourceCopyPropertiesAtIndex(source, 0, (__bridge CFDictionaryRef)options);
+    if (properties) {
+        dictionary = (__bridge NSDictionary*)properties;
+        CFRelease(properties);
+    }
+    
+    CFRelease(source);
+    
+    return [self metadataWithDictionary:dictionary];
+}
+
++ (instancetype)metadataWithImageData:(NSData *)imageData
+{
+    if (!imageData.length)
+        return nil;
+    
+    CGImageSourceRef source = CGImageSourceCreateWithData((__bridge CFDataRef) imageData, NULL);
+    if (source == NULL)
+        return nil;
+    
+    NSDictionary *dictionary;
+    
+    NSDictionary *options = @{(NSString *)kCGImageSourceShouldCache:@(NO)};
+    CFDictionaryRef properties = CGImageSourceCopyPropertiesAtIndex(source, 0, (__bridge CFDictionaryRef)options);
+    if (properties) {
+        dictionary = (__bridge NSDictionary*)properties;
+        CFRelease(properties);
+    }
+    
+    CFRelease(source);
+    
+    return [self metadataWithDictionary:dictionary];
+}
+
+#pragma mark - Writing
+
+// https://github.com/Nikita2k/SimpleExif/blob/master/Classes/ios/UIImage%2BExif.m
++ (NSData *)dataWithImageData:(NSData *)imageData andMetadata:(SYMetadata *)metadata
+{
+    CGImageSourceRef source = CGImageSourceCreateWithData((__bridge CFDataRef) imageData, NULL);
+    if (!source) {
+        NSLog(@"Error: Could not create image source");
+        return nil;
+    }
+    
+    CFStringRef sourceImageType = CGImageSourceGetType(source);
+    
+    // create a new data object and write the new image into it
+    NSMutableData *data = [NSMutableData data];
+    CGImageDestinationRef destination = CGImageDestinationCreateWithData((__bridge CFMutableDataRef)data, sourceImageType, 1, NULL);
+    
+    if (!destination) {
+        NSLog(@"Error: Could not create image destination");
+        CFRelease(source);
+        return nil;
+    }
+    
+    // add the image contained in the image source to the destination, overidding the old metadata with our modified metadata
+    CGImageDestinationAddImageFromSource(destination, source, 0, (__bridge CFDictionaryRef)metadata.generatedDictionary);
+    BOOL success = CGImageDestinationFinalize(destination);
+    
+    if (!success)
+        NSLog(@"Error: Could not create data from image destination");
+    
+    CFRelease(destination);
+    CFRelease(source);
+    
+    return (success ? data : nil);
+}
+
+#pragma mark - Getting metadata
+
++ (NSDictionary *)dictionaryWithAssetURL:(NSURL *)assetURL
+{
+#if !TARGET_OS_TV
+    __block ALAsset *assetAtUrl = nil;
+    ALAssetsLibrary* library = [[ALAssetsLibrary alloc] init];
+    
+    dispatch_semaphore_t sema = dispatch_semaphore_create(0);
+    [library assetForURL:assetURL resultBlock:^(ALAsset *asset) {
+        assetAtUrl = asset;
+        dispatch_semaphore_signal(sema);
+    } failureBlock:^(NSError *error) {
+        dispatch_semaphore_signal(sema);
+    }];
+    dispatch_semaphore_wait(sema, DISPATCH_TIME_FOREVER);
+    
+    if (!assetAtUrl)
+        return nil;
+    
+    ALAssetRepresentation *representation = [assetAtUrl defaultRepresentation];
+    return [representation metadata];
+#else
+    return nil;
+#endif
+}
+
+#pragma mark - Mapping
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey
+{
+    NSMutableDictionary <NSString *, NSString *> *mappings = [NSMutableDictionary dictionary];
+    [mappings
+     addEntriesFromDictionary:@{SYMappingPptyToKeyPath(TIFF),
+                                SYMappingPptyToKeyPath(Exif),
+                                SYMappingPptyToKeyPath(GIF),
+                                SYMappingPptyToKeyPath(JFIF),
+                                SYMappingPptyToKeyPath(PNG),
+                                SYMappingPptyToKeyPath(IPTC),
+                                SYMappingPptyToKeyPath(GPS),
+                                SYMappingPptyToKeyPath(Raw),
+                                SYMappingPptyToKeyPath(CIFF),
+                                SYMappingPptyToKeyPath(MakerCanon),
+                                SYMappingPptyToKeyPath(MakerNikon),
+                                SYMappingPptyToKeyPath(MakerMinolta),
+                                SYMappingPptyToKeyPath(MakerFuji),
+                                SYMappingPptyToKeyPath(MakerOlympus),
+                                SYMappingPptyToKeyPath(MakerPentax),
+                                SYMappingPptyToKeyPath(8BIM),
+                                SYMappingPptyToKeyPath(DNG),
+                                SYMappingPptyToKeyPath(ExifAux),
+                                }];
+    
+    [mappings
+     addEntriesFromDictionary:@{SYStringSel(fileSize):      (NSString *)kCGImagePropertyFileSize,
+                                SYStringSel(pixelHeight):   (NSString *)kCGImagePropertyPixelHeight,
+                                SYStringSel(pixelWidth):    (NSString *)kCGImagePropertyPixelWidth,
+                                SYStringSel(dpiHeight):     (NSString *)kCGImagePropertyDPIHeight,
+                                SYStringSel(dpiWidth):      (NSString *)kCGImagePropertyDPIWidth,
+                                SYStringSel(depth):         (NSString *)kCGImagePropertyDepth,
+                                SYStringSel(orientation):   (NSString *)kCGImagePropertyOrientation,
+                                SYStringSel(isFloat):       (NSString *)kCGImagePropertyIsFloat,
+                                SYStringSel(isIndexed):     (NSString *)kCGImagePropertyIsIndexed,
+                                SYStringSel(hasAlpha):      (NSString *)kCGImagePropertyHasAlpha,
+                                SYStringSel(colorModel):    (NSString *)kCGImagePropertyColorModel,
+                                SYStringSel(profileName):   (NSString *)kCGImagePropertyProfileName,
+                                
+                                SYStringSel(metadataApple):         (NSString *)kCGImagePropertyMakerAppleDictionary,
+                                SYStringSel(metadataPictureStyle):  (NSString *)kSYImagePropertyPictureStyle,
+                                }];
+    
+    return [mappings copy];
+}
+
++ (NSValueTransformer *)JSONTransformerForKey:(NSString *)key
+{
+    static dispatch_once_t onceToken;
+    static NSDictionary <NSString *, Class> *classMappings;
+    dispatch_once(&onceToken, ^{
+        classMappings = @{SYMappingPptyToClass(TIFF),
+                          SYMappingPptyToClass(Exif),
+                          SYMappingPptyToClass(GIF),
+                          SYMappingPptyToClass(JFIF),
+                          SYMappingPptyToClass(PNG),
+                          SYMappingPptyToClass(IPTC),
+                          SYMappingPptyToClass(GPS),
+                          SYMappingPptyToClass(Raw),
+                          SYMappingPptyToClass(CIFF),
+                          SYMappingPptyToClass(MakerCanon),
+                          SYMappingPptyToClass(MakerNikon),
+                          SYMappingPptyToClass(MakerMinolta),
+                          SYMappingPptyToClass(MakerFuji),
+                          SYMappingPptyToClass(MakerOlympus),
+                          SYMappingPptyToClass(MakerPentax),
+                          SYMappingPptyToClass(8BIM),
+                          SYMappingPptyToClass(DNG),
+                          SYMappingPptyToClass(ExifAux),
+                          };
+    });
+    
+    
+    Class objectClass = classMappings[key];
+    
+    if (objectClass)
+        return [NSValueTransformer sy_dictionaryTransformerForModelOfClass:objectClass];
+    
+    return [super JSONTransformerForKey:key];
+}
+
+#pragma mark - Tests
+
+- (NSDictionary *)differencesFromOriginalMetadataToModel
+{
+    return [NSDictionary sy_differencesFrom:self.originalDictionary
+                                         to:[self generatedDictionary]
+                        includeValuesInDiff:YES];
+}
+
+@end

--- a/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadata8BIM.h
+++ b/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadata8BIM.h
@@ -1,0 +1,16 @@
+//
+//  SYMetadata8BIM.h
+//  SYPictureMetadataExample
+//
+//  Created by Stan Chevallier on 12/16/12.
+//  Copyright (c) 2012 Syan. All rights reserved.
+//
+
+#import "SYMetadataBase.h"
+
+@interface SYMetadata8BIM : SYMetadataBase
+
+@property SYMETADATA_PROPERTY_COPY NSArray <NSString *>  *layerNames;
+@property SYMETADATA_PROPERTY_COPY NSNumber              *version;
+
+@end

--- a/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadata8BIM.m
+++ b/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadata8BIM.m
@@ -1,0 +1,22 @@
+//
+//  SYMetadata8BIM.m
+//  SYPictureMetadataExample
+//
+//  Created by Stan Chevallier on 12/16/12.
+//  Copyright (c) 2012 Syan. All rights reserved.
+//
+
+#import "SYMetadata8BIM.h"
+#import <ImageIO/ImageIO.h>
+
+@implementation SYMetadata8BIM
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey
+{
+    return @{SYStringSel(layerNames):   (NSString *)kCGImageProperty8BIMLayerNames,
+             SYStringSel(version):      (NSString *)kCGImageProperty8BIMVersion,
+             };
+}
+
+@end
+

--- a/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadataBase.h
+++ b/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadataBase.h
@@ -1,0 +1,42 @@
+//
+//  SYMetadataBase.h
+//  SYPictureMetadataExample
+//
+//  Created by Stan Chevallier on 12/13/12.
+//  Copyright (c) 2012 Syan. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+@import Mantle;
+
+#define SYPaste1(a,b)                   a##b
+#define SYPaste(a,b)                    SYPaste1(a,b)
+#define SYStringSel(sel)                NSStringFromSelector(@selector(sel))
+
+// keys not available in public header, but still read by iOS
+extern CFStringRef const kSYImagePropertyExifAuxAutoFocusInfo;
+extern CFStringRef const kSYImagePropertyExifAuxImageStabilization;
+extern CFStringRef const kSYImagePropertyCIFFMaxAperture;
+extern CFStringRef const kSYImagePropertyCIFFMinAperture;
+extern CFStringRef const kSYImagePropertyCIFFUniqueModelID;
+extern CFStringRef const kSYImagePropertyPictureStyle;
+
+// allows to easily switch between read-only and R/W properties
+#define SYMETADATA_PROPERTY_COPY    (nonatomic, copy)
+#define SYMETADATA_PROPERTY_STRONG  (nonatomic, strong)
+
+@interface MTLValueTransformer (SY)
++ (instancetype)sy_nonZeroIntegerValueTransformer;
+@end
+
+@interface NSValueTransformer (SY)
++ (instancetype)sy_dictionaryTransformerForModelOfClass:(Class)modelClass;
+- (Class)sy_dictionaryTransformerModelClass;
+@end
+
+@interface SYMetadataBase : MTLModel <MTLJSONSerializing>
+
+- (NSDictionary *)generatedDictionary;
++ (NSArray <NSString *> *)supportedKeys;
+
+@end

--- a/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadataBase.m
+++ b/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadataBase.m
@@ -1,0 +1,167 @@
+//
+//  SYMetadataBase.m
+//  SYPictureMetadataExample
+//
+//  Created by Stan Chevallier on 12/13/12.
+//  Copyright (c) 2012 Syan. All rights reserved.
+//
+
+#import "SYMetadataBase.h"
+#import <ImageIO/ImageIO.h>
+#import <objc/runtime.h>
+
+#if TARGET_IPHONE_SIMULATOR && __IPHONE_OS_VERSION_MIN_REQUIRED < 90000
+// keys needed for simulator < 9.0
+//CFStringRef const kCGImagePropertyAPNGDelayTime                 = CFSTR("DelayTime");
+//CFStringRef const kCGImagePropertyAPNGLoopCount                 = CFSTR("LoopCount");
+//CFStringRef const kCGImagePropertyAPNGUnclampedDelayTime        = CFSTR("UnclampedDelayTime");
+CFStringRef const kCGImagePropertyMakerFujiDictionary           = CFSTR("{MakerFuji}");
+CFStringRef const kCGImagePropertyMakerMinoltaDictionary        = CFSTR("{MakerMinolta}");
+CFStringRef const kCGImagePropertyMakerOlympusDictionary        = CFSTR("{MakerOlympus}");
+CFStringRef const kCGImagePropertyMakerPentaxDictionary         = CFSTR("{MakerPentax}");
+#endif
+
+#if TARGET_IPHONE_SIMULATOR && __IPHONE_OS_VERSION_MIN_REQUIRED < 100000
+// keys needed for simulator < 10.0
+CFStringRef const kCGImageProperty8BIMVersion                   = CFSTR("Version");
+#endif
+
+#if !TARGET_IPHONE_SIMULATOR && __IPHONE_OS_VERSION_MIN_REQUIRED < 80000
+// keys available since iOS 8+, exported here for < 8.0
+CFStringRef const kCGImagePropertyGPSHPositioningError          = CFSTR("HPositioningError");
+#endif
+
+#if !TARGET_IPHONE_SIMULATOR && __IPHONE_OS_VERSION_MIN_REQUIRED < 90000
+// keys available since iOS 9+, exported here for < 9.0
+CFStringRef const kCGImagePropertyTIFFTileWidth                 = CFSTR("TileWidth");
+CFStringRef const kCGImagePropertyTIFFTileLength                = CFSTR("TileLength");
+CFStringRef const kCGImagePropertyPNGCompressionFilter          = CFSTR("kCGImagePropertyPNGCompressionFilter");
+// keys available since iOS 8+ according to header, but not actually available...
+//CFStringRef const kCGImagePropertyAPNGDelayTime                 = CFSTR("DelayTime");
+//CFStringRef const kCGImagePropertyAPNGLoopCount                 = CFSTR("LoopCount");
+//CFStringRef const kCGImagePropertyAPNGUnclampedDelayTime        = CFSTR("UnclampedDelayTime");
+#endif
+
+#if !TARGET_IPHONE_SIMULATOR && __IPHONE_OS_VERSION_MIN_REQUIRED < 100000
+// keys available since iOS 8+ according to header, but not actually available...
+CFStringRef const kCGImageProperty8BIMVersion                   = CFSTR("Version");
+// keys available since iOS 10+, exported here for < 10.0
+CFStringRef const kCGImagePropertyDNGBlackLevel                 = CFSTR("BlackLevel");
+CFStringRef const kCGImagePropertyDNGWhiteLevel                 = CFSTR("WhiteLevel");
+CFStringRef const kCGImagePropertyDNGCalibrationIlluminant1     = CFSTR("CalibrationIlluminant1");
+CFStringRef const kCGImagePropertyDNGCalibrationIlluminant2     = CFSTR("CalibrationIlluminant2");
+CFStringRef const kCGImagePropertyDNGColorMatrix1               = CFSTR("ColorMatrix1");
+CFStringRef const kCGImagePropertyDNGColorMatrix2               = CFSTR("ColorMatrix2");
+CFStringRef const kCGImagePropertyDNGCameraCalibration1         = CFSTR("CameraCalibration1");
+CFStringRef const kCGImagePropertyDNGCameraCalibration2         = CFSTR("CameraCalibration2");
+CFStringRef const kCGImagePropertyDNGAsShotNeutral              = CFSTR("AsShotNeutral");
+CFStringRef const kCGImagePropertyDNGAsShotWhiteXY              = CFSTR("AsShotWhiteXY");
+CFStringRef const kCGImagePropertyDNGBaselineExposure           = CFSTR("BaselineExposure");
+CFStringRef const kCGImagePropertyDNGBaselineNoise              = CFSTR("BaselineNoise");
+CFStringRef const kCGImagePropertyDNGBaselineSharpness          = CFSTR("BaselineSharpness");
+CFStringRef const kCGImagePropertyDNGPrivateData                = CFSTR("DNGPrivateData");
+CFStringRef const kCGImagePropertyDNGCameraCalibrationSignature = CFSTR("CameraCalibrationSignature");
+CFStringRef const kCGImagePropertyDNGProfileCalibrationSignature= CFSTR("ProfileCalibrationSignature");
+CFStringRef const kCGImagePropertyDNGNoiseProfile               = CFSTR("NoiseProfile");
+CFStringRef const kCGImagePropertyDNGWarpRectilinear            = CFSTR("WarpRectilinear");
+CFStringRef const kCGImagePropertyDNGWarpFisheye                = CFSTR("WarpFisheye");
+CFStringRef const kCGImagePropertyDNGFixVignetteRadial          = CFSTR("FixVignetteRadial");
+#endif
+
+// not defined in ImageIO but still read by iOS
+CFStringRef const kSYImagePropertyPictureStyle                  = CFSTR("{PictureStyle}");
+CFStringRef const kSYImagePropertyExifAuxAutoFocusInfo          = CFSTR("AFInfo");
+CFStringRef const kSYImagePropertyExifAuxImageStabilization     = CFSTR("ImageStabilization");
+CFStringRef const kSYImagePropertyCIFFMaxAperture               = CFSTR("MaxAperture");
+CFStringRef const kSYImagePropertyCIFFMinAperture               = CFSTR("MinAperture");
+CFStringRef const kSYImagePropertyCIFFUniqueModelID             = CFSTR("UniqueModelID");
+
+@implementation SYMetadataBase
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey
+{
+    return @{};
+}
+
++ (NSValueTransformer *)JSONTransformerForKey:(NSString *)key
+{
+    // default transformer to prevents NSNull in generated dictionary
+    return [MTLValueTransformer transformerUsingForwardBlock:^id(id value, BOOL *success, NSError *__autoreleasing *error) {
+        return value;
+    } reverseBlock:^id(id value, BOOL *success, NSError *__autoreleasing *error) {
+        return value;
+    }];
+}
+
++ (NSArray <NSString *> *)supportedKeys
+{
+    NSMutableArray <NSString *> *keys = [NSMutableArray array];
+    
+    NSDictionary *mappings = [self JSONKeyPathsByPropertyKey];
+    for (NSString *key in mappings)
+    {
+        [keys addObject:mappings[key]];
+        
+        NSValueTransformer *transformer = [self JSONTransformerForKey:key];
+        Class modelClass = [transformer sy_dictionaryTransformerModelClass];
+        
+        if ([(NSObject *)modelClass respondsToSelector:@selector(supportedKeys)])
+        {
+            NSArray <NSString *> *subkeys = [modelClass supportedKeys];
+            for (NSString *subkey in subkeys)
+                [keys addObject:[@[mappings[key], subkey] componentsJoinedByString:@"."]];
+        }
+    }
+    
+    return [keys copy];
+}
+
+- (NSDictionary *)generatedDictionary
+{
+    NSError *error;
+    NSMutableDictionary *dictionary = [[MTLJSONAdapter JSONDictionaryFromModel:self error:&error] mutableCopy];
+    
+    if (error)
+        NSLog(@"--> Error for class %@: %@", NSStringFromClass(self.class), error);
+    
+    [dictionary removeObjectsForKeys:[dictionary allKeysForObject:[NSNull null]]];
+    return [dictionary copy];
+}
+
+@end
+
+@implementation MTLValueTransformer (SY)
+
++ (instancetype)sy_nonZeroIntegerValueTransformer
+{
+    return [MTLValueTransformer transformerUsingForwardBlock:^id(id value, BOOL *success, NSError *__autoreleasing *error) {
+        return value;
+    } reverseBlock:^id(id value, BOOL *success, NSError *__autoreleasing *error) {
+        if ([value integerValue] == 0)
+            return nil;
+        return value;
+    }];
+}
+
+@end
+
+@implementation NSValueTransformer (SY)
+
++ (instancetype)sy_dictionaryTransformerForModelOfClass:(Class)modelClass
+{
+    NSValueTransformer <MTLTransformerErrorHandling> *instance = [MTLJSONAdapter dictionaryTransformerWithModelClass:modelClass];
+    
+    if (instance)
+        objc_setAssociatedObject(instance, @selector(sy_dictionaryTransformerModelClass), NSStringFromClass(modelClass), OBJC_ASSOCIATION_COPY);
+    
+    return instance;
+}
+
+- (Class)sy_dictionaryTransformerModelClass
+{
+    NSString *classString = objc_getAssociatedObject(self, @selector(sy_dictionaryTransformerModelClass));
+    return (classString ? NSClassFromString(classString) : nil);
+}
+
+@end
+

--- a/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadataCIFF.h
+++ b/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadataCIFF.h
@@ -1,0 +1,40 @@
+//
+//  SYMetadataCIFF.h
+//  SYPictureMetadataExample
+//
+//  Created by Stan Chevallier on 12/16/12.
+//  Copyright (c) 2012 Syan. All rights reserved.
+//
+
+#import "SYMetadataBase.h"
+
+// https://raw.githubusercontent.com/wiki/drewnoakes/metadata-extractor/docs/CIFFspecV1R04.pdf
+
+@interface SYMetadataCIFF : SYMetadataBase
+
+@property SYMETADATA_PROPERTY_COPY NSString  *descr;
+@property SYMETADATA_PROPERTY_COPY NSString  *firmware;
+@property SYMETADATA_PROPERTY_COPY NSString  *ownerName;
+@property SYMETADATA_PROPERTY_COPY NSString  *imageName;
+@property SYMETADATA_PROPERTY_COPY NSString  *imageFileName;
+@property SYMETADATA_PROPERTY_COPY NSNumber  *releaseMethod;
+@property SYMETADATA_PROPERTY_COPY NSNumber  *releaseTiming;
+@property SYMETADATA_PROPERTY_COPY NSNumber  *recordID;
+@property SYMETADATA_PROPERTY_COPY NSNumber  *selfTimingTime;
+@property SYMETADATA_PROPERTY_COPY NSNumber  *cameraSerialNumber;
+@property SYMETADATA_PROPERTY_COPY NSNumber  *imageSerialNumber;
+@property SYMETADATA_PROPERTY_COPY NSNumber  *continuousDrive;
+@property SYMETADATA_PROPERTY_COPY NSNumber  *focusMode;
+@property SYMETADATA_PROPERTY_COPY NSNumber  *meteringMode;
+@property SYMETADATA_PROPERTY_COPY NSNumber  *shootingMode;
+@property SYMETADATA_PROPERTY_COPY NSString  *lensModel;
+@property SYMETADATA_PROPERTY_COPY NSNumber  *lensMaxMM;
+@property SYMETADATA_PROPERTY_COPY NSNumber  *lensMinMM;
+@property SYMETADATA_PROPERTY_COPY NSNumber  *whiteBalanceIndex;
+@property SYMETADATA_PROPERTY_COPY NSNumber  *flashExposureComp;
+@property SYMETADATA_PROPERTY_COPY NSNumber  *measuredEV;
+@property SYMETADATA_PROPERTY_COPY NSNumber  *uniqueModelID;
+@property SYMETADATA_PROPERTY_COPY NSNumber  *maxAperture;
+@property SYMETADATA_PROPERTY_COPY NSNumber  *minAperture;
+
+@end

--- a/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadataCIFF.m
+++ b/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadataCIFF.m
@@ -1,0 +1,44 @@
+//
+//  SYMetadataCIFF.m
+//  SYPictureMetadataExample
+//
+//  Created by Stan Chevallier on 12/16/12.
+//  Copyright (c) 2012 Syan. All rights reserved.
+//
+
+#import "SYMetadataCIFF.h"
+#import <ImageIO/ImageIO.h>
+
+@implementation SYMetadataCIFF
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey
+{
+    return @{SYStringSel(descr):                (NSString *)kCGImagePropertyCIFFDescription,
+             SYStringSel(firmware):             (NSString *)kCGImagePropertyCIFFFirmware,
+             SYStringSel(ownerName):            (NSString *)kCGImagePropertyCIFFOwnerName,
+             SYStringSel(imageName):            (NSString *)kCGImagePropertyCIFFImageName,
+             SYStringSel(imageFileName):        (NSString *)kCGImagePropertyCIFFImageFileName,
+             SYStringSel(releaseMethod):        (NSString *)kCGImagePropertyCIFFReleaseMethod,
+             SYStringSel(releaseTiming):        (NSString *)kCGImagePropertyCIFFReleaseTiming,
+             SYStringSel(recordID):             (NSString *)kCGImagePropertyCIFFRecordID,
+             SYStringSel(selfTimingTime):       (NSString *)kCGImagePropertyCIFFSelfTimingTime,
+             SYStringSel(cameraSerialNumber):   (NSString *)kCGImagePropertyCIFFCameraSerialNumber,
+             SYStringSel(imageSerialNumber):    (NSString *)kCGImagePropertyCIFFImageSerialNumber,
+             SYStringSel(continuousDrive):      (NSString *)kCGImagePropertyCIFFContinuousDrive,
+             SYStringSel(focusMode):            (NSString *)kCGImagePropertyCIFFFocusMode,
+             SYStringSel(meteringMode):         (NSString *)kCGImagePropertyCIFFMeteringMode,
+             SYStringSel(shootingMode):         (NSString *)kCGImagePropertyCIFFShootingMode,
+             SYStringSel(lensModel):            (NSString *)kCGImagePropertyCIFFLensModel,
+             SYStringSel(lensMaxMM):            (NSString *)kCGImagePropertyCIFFLensMaxMM,
+             SYStringSel(lensMinMM):            (NSString *)kCGImagePropertyCIFFLensMinMM,
+             SYStringSel(whiteBalanceIndex):    (NSString *)kCGImagePropertyCIFFWhiteBalanceIndex,
+             SYStringSel(flashExposureComp):    (NSString *)kCGImagePropertyCIFFFlashExposureComp,
+             SYStringSel(measuredEV):           (NSString *)kCGImagePropertyCIFFMeasuredEV,
+             
+             SYStringSel(maxAperture):          (NSString *)kSYImagePropertyCIFFMaxAperture,
+             SYStringSel(minAperture):          (NSString *)kSYImagePropertyCIFFMinAperture,
+             SYStringSel(uniqueModelID):        (NSString *)kSYImagePropertyCIFFUniqueModelID,
+             };
+}
+
+@end

--- a/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadataDNG.h
+++ b/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadataDNG.h
@@ -1,0 +1,42 @@
+//
+//  SYMetadataDNG.h
+//  SYPictureMetadataExample
+//
+//  Created by Stan Chevallier on 12/16/12.
+//  Copyright (c) 2012 Syan. All rights reserved.
+//
+
+#import "SYMetadataBase.h"
+
+// https://www.adobe.com/content/dam/Adobe/en/products/photoshop/pdfs/dng_spec_1.4.0.0.pdf
+@interface SYMetadataDNG : SYMetadataBase
+
+@property SYMETADATA_PROPERTY_COPY NSArray <NSNumber *>  *version;
+@property SYMETADATA_PROPERTY_COPY NSArray <NSNumber *>  *backwardVersion;
+@property SYMETADATA_PROPERTY_COPY NSString              *uniqueCameraModel;
+@property SYMETADATA_PROPERTY_COPY NSString              *localizedCameraModel;
+@property SYMETADATA_PROPERTY_COPY NSString              *cameraSerialNumber;
+@property SYMETADATA_PROPERTY_COPY NSArray <NSNumber *>  *lensInfo;
+
+@property SYMETADATA_PROPERTY_COPY NSArray <NSNumber *>  *blackLevel;
+@property SYMETADATA_PROPERTY_COPY NSArray <NSNumber *>  *whiteLevel;
+@property SYMETADATA_PROPERTY_COPY NSNumber              *calibrationIlluminant1;
+@property SYMETADATA_PROPERTY_COPY NSNumber              *calibrationIlluminant2;
+@property SYMETADATA_PROPERTY_COPY NSArray <NSNumber *>  *colorMatrix1;
+@property SYMETADATA_PROPERTY_COPY NSArray <NSNumber *>  *colorMatrix2;
+@property SYMETADATA_PROPERTY_COPY NSArray <NSNumber *>  *cameraCalibration1;
+@property SYMETADATA_PROPERTY_COPY NSArray <NSNumber *>  *cameraCalibration2;
+@property SYMETADATA_PROPERTY_COPY NSArray <NSNumber *>  *asShotNeutral;
+@property SYMETADATA_PROPERTY_COPY NSArray <NSNumber *>  *asShotWhiteXY;
+@property SYMETADATA_PROPERTY_COPY NSNumber              *baselineExposure;
+@property SYMETADATA_PROPERTY_COPY NSNumber              *baselineNoise;
+@property SYMETADATA_PROPERTY_COPY NSNumber              *baselineSharpness;
+@property SYMETADATA_PROPERTY_COPY NSObject              *privateData;
+@property SYMETADATA_PROPERTY_COPY NSString              *cameraCalibrationSignature;
+@property SYMETADATA_PROPERTY_COPY NSString              *profileCalibrationSignature;
+@property SYMETADATA_PROPERTY_COPY NSArray <NSNumber *>  *noiseProfile;
+@property SYMETADATA_PROPERTY_COPY NSArray <NSNumber *>  *warpRectilinear;
+@property SYMETADATA_PROPERTY_COPY NSArray <NSNumber *>  *warpFisheye;
+@property SYMETADATA_PROPERTY_COPY NSArray <NSNumber *>  *fixVignetteRadial;
+
+@end

--- a/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadataDNG.m
+++ b/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadataDNG.m
@@ -1,0 +1,27 @@
+//
+//  SYMetadataDNG.m
+//  SYPictureMetadataExample
+//
+//  Created by Stan Chevallier on 12/16/12.
+//  Copyright (c) 2012 Syan. All rights reserved.
+//
+
+#import "SYMetadataDNG.h"
+#import <ImageIO/ImageIO.h>
+
+@implementation SYMetadataDNG
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey
+{
+    return @{SYStringSel(version):              (NSString *)kCGImagePropertyDNGVersion,
+             SYStringSel(backwardVersion):      (NSString *)kCGImagePropertyDNGBackwardVersion,
+             SYStringSel(uniqueCameraModel):    (NSString *)kCGImagePropertyDNGUniqueCameraModel,
+             SYStringSel(localizedCameraModel): (NSString *)kCGImagePropertyDNGLocalizedCameraModel,
+             SYStringSel(cameraSerialNumber):   (NSString *)kCGImagePropertyDNGCameraSerialNumber,
+             SYStringSel(lensInfo):             (NSString *)kCGImagePropertyDNGLensInfo,
+             
+             
+             };
+}
+
+@end

--- a/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadataExif.h
+++ b/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadataExif.h
@@ -1,0 +1,242 @@
+//
+//  SYMetadataExif.h
+//  SYPictureMetadataExample
+//
+//  Created by Stan Chevallier on 12/13/12.
+//  Copyright (c) 2012 Syan. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "SYMetadataBase.h"
+
+typedef enum {
+    SYPictureExifExposureProgram_NotDefined = 0,
+    SYPictureExifExposureProgram_Manual = 1,
+    SYPictureExifExposureProgram_NormalProgram = 2,
+    SYPictureExifExposureProgram_AperturePriority = 3,
+    SYPictureExifExposureProgram_ShutterPriority = 4,
+    SYPictureExifExposureProgram_CreativeProgram = 5, // (biased toward depth of field)
+    SYPictureExifExposureProgram_ActionProgram = 6, // (biased toward fast shutter speed)
+    SYPictureExifExposureProgram_PortraitMode = 7, // (for closeup photos with the background out of focus)
+    SYPictureExifExposureProgram_LandscapeMode = 8 // (for landscape photos with the background in focus)
+} SYPictureExifExposureProgram;
+
+typedef enum {
+    SYPictureExifMeteringMode_Unknown = 0,
+    SYPictureExifMeteringMode_Average = 1,
+    SYPictureExifMeteringMode_CenterWeightedAverage = 2,
+    SYPictureExifMeteringMode_Spot = 3,
+    SYPictureExifMeteringMode_MultiSpot = 4,
+    SYPictureExifMeteringMode_Pattern = 5,
+    SYPictureExifMeteringMode_Partial = 6,
+    SYPictureExifMeteringMode_Other = 255
+} SYPictureExifMeteringMode;
+
+typedef enum {
+    SYPictureExifLightSource_Unknown = 0,
+    SYPictureExifLightSource_Daylight = 1,
+    SYPictureExifLightSource_Fluorescent = 2,
+    SYPictureExifLightSource_TungstenIncandescentLight = 3,
+    SYPictureExifLightSource_Flash = 4,
+    SYPictureExifLightSource_FineWeather = 9,
+    SYPictureExifLightSource_CloudyWeather = 10,
+    SYPictureExifLightSource_Shade = 11,
+    SYPictureExifLightSource_DaylightFluorescent = 12, // (D 5700 - 7100K)
+    SYPictureExifLightSource_DayWhiteFluorescent = 13, // (N 4600 - 5400K)
+    SYPictureExifLightSource_CoolWhiteFluorescent = 14, // (W 3900 - 4500K)
+    SYPictureExifLightSource_WhiteFluorescent = 15, // (WW 3200 - 3700K)
+    SYPictureExifLightSource_StandardLightA = 17,
+    SYPictureExifLightSource_StandardLightB = 18,
+    SYPictureExifLightSource_StandardLightC = 19,
+    SYPictureExifLightSource_D55 = 20,
+    SYPictureExifLightSource_D65 = 21,
+    SYPictureExifLightSource_D75 = 22,
+    SYPictureExifLightSource_D50 = 23,
+    SYPictureExifLightSource_ISOStudioTungsten = 24,
+    SYPictureExifLightSource_OtherLightSource = 255
+} SYPictureExifLightSource;
+
+typedef enum {
+    SYPictureExifFocalPlaneResolutionUnit_NoAbsoluteUnitOfMeasurement = 1,
+    SYPictureExifFocalPlaneResolutionUnit_Inch = 2,
+    SYPictureExifFocalPlaneResolutionUnit_Centimeter = 3
+} SYPictureExifFocalPlaneResolutionUnit;
+
+typedef enum {
+    SYPictureExifSensingMethod_NotDefined = 1,
+    SYPictureExifSensingMethod_OneChipColorAreaSensor = 2,
+    SYPictureExifSensingMethod_TwoChipColorAreaSensor = 3,
+    SYPictureExifSensingMethod_ThreeChipColorAreaSensor = 4,
+    SYPictureExifSensingMethod_ColorSequentialAreaSensor = 5,
+    SYPictureExifSensingMethod_TrilinearSensor = 7,
+    SYPictureExifSensingMethod_ColorSequentialLinearSensor = 8
+} SYPictureExifSensingMethod;
+
+typedef enum {
+    SYPictureExifCustomRendered_NormalProcess = 0,
+    SYPictureExifCustomRendered_CustomProcess = 1
+} SYPictureExifCustomRendered;
+
+typedef enum {
+    SYPictureExifExposureMode_AutoExposure = 0,
+    SYPictureExifExposureMode_ManualExposure = 1,
+    SYPictureExifExposureMode_AutoBracket = 2
+} SYPictureExifExposureMode;
+
+typedef enum {
+    SYPictureExifWhiteBalance_Auto = 0,
+    SYPictureExifWhiteBalance_Manual = 1
+} SYPictureExifWhiteBalance;
+
+typedef enum {
+    SYPictureExifSceneCaptureType_Standard = 0,
+    SYPictureExifSceneCaptureType_Landscape = 1,
+    SYPictureExifSceneCaptureType_Portrait = 2,
+    SYPictureExifSceneCaptureType_NightScene = 3
+} SYPictureExifSceneCaptureType;
+
+typedef enum {
+    SYPictureExifGainControl_None = 0,
+    SYPictureExifGainControl_LowGainUp = 1,
+    SYPictureExifGainControl_HighGainUp = 2,
+    SYPictureExifGainControl_LowGainDown = 3,
+    SYPictureExifGainControl_HighGainDown = 4
+} SYPictureExifGainControl;
+
+typedef enum {
+    SYPictureExifContrast_Normal = 0,
+    SYPictureExifContrast_Soft = 1,
+    SYPictureExifContrast_Hard = 2
+} SYPictureExifContrast;
+
+typedef enum {
+    SYPictureExifSaturation_Normal = 0,
+    SYPictureExifSaturation_LowSaturation = 1,
+    SYPictureExifSaturation_HighSaturation = 2
+} SYPictureExifSaturation;
+
+typedef enum {
+    SYPictureExifSharpness_Normal = 0,
+    SYPictureExifSharpness_Soft = 1,
+    SYPictureExifSharpness_Hard = 2
+} SYPictureExifSharpness;
+
+typedef enum {
+    SYPictureExifSubjectDistanceRange_Unknown = 0,
+    SYPictureExifSubjectDistanceRange_Macro = 1,
+    SYPictureExifSubjectDistanceRange_CloseView = 2,
+    SYPictureExifSubjectDistanceRange_DistantView = 3
+} SYPictureExifSubjectDistanceRange;
+
+typedef enum : NSUInteger {
+    SYMetadataExifSensitivityType_Unknown                                                          = 0,
+    SYMetadataExifSensitivityType_StandardOutputSensitivity                                        = 1,
+    SYMetadataExifSensitivityType_RecommendedExposureIndex                                         = 2,
+    SYMetadataExifSensitivityType_ISOSpeed                                                         = 3,
+    SYMetadataExifSensitivityType_StandardOutputSensitivityAndRecommendedExposureIndex             = 4,
+    SYMetadataExifSensitivityType_StandardOutputSensitivityAndISOSpeed                             = 5,
+    SYMetadataExifSensitivityType_RecommendedExposureIndexAndISOSpeed                              = 6,
+    SYMetadataExifSensitivityType_StandardOutputSensitivityAndRecommendedExposureIndexAndISOSpeed  = 7,
+} SYMetadataExifSensitivityType;
+
+typedef enum : NSUInteger {
+    SYMetadataExifFlash_FlashDidNotFire                                                        = 0x0000,
+    SYMetadataExifFlash_FlashFired                                                             = 0x0001,
+    SYMetadataExifFlash_StrobeReturnLightNotDetected                                           = 0x0005,
+    SYMetadataExifFlash_StrobeReturnLightDetected                                              = 0x0007,
+    SYMetadataExifFlash_FlashFiredCompulsoryFlashMode                                          = 0x0009,
+    SYMetadataExifFlash_FlashFiredCompulsoryFlashModeReturnLightNotDetected                    = 0x000D,
+    SYMetadataExifFlash_FlashFiredCompulsoryFlashModeReturnLightDetected                       = 0x000F,
+    SYMetadataExifFlash_FlashDidNotFireCompulsoryDlashMode                                     = 0x0010,
+    SYMetadataExifFlash_FlashDidNotFireAutoMode                                                = 0x0018,
+    SYMetadataExifFlash_FlashFiredAutoMode                                                     = 0x0019,
+    SYMetadataExifFlash_FlashFiredAutoModeReturnLightNotDetected                               = 0x001D,
+    SYMetadataExifFlash_FlashFiredAutoModeReturnLightDetected                                  = 0x001F,
+    SYMetadataExifFlash_NoFlashFunction                                                        = 0x0020,
+    SYMetadataExifFlash_FlashFiredRedEyeReductionMode                                          = 0x0041,
+    SYMetadataExifFlash_FlashFiredRedEyeReductionModeReturnLightNotDetected                    = 0x0045,
+    SYMetadataExifFlash_FlashFiredRedEyeReductionModeReturnLightDetected                       = 0x0047,
+    SYMetadataExifFlash_FlashFiredCompulsoryFlashModeRedEyeReductionMode                       = 0x0049,
+    SYMetadataExifFlash_FlashFiredCompulsoryFlashModeRedEyeReductionModeReturnLightNotDetected = 0x004D,
+    SYMetadataExifFlash_FlashFiredCompulsoryFlashModeRedEyeReductionModeReturnLightDetected    = 0x004F,
+    SYMetadataExifFlash_FlashFiredAutoModeRedEyeReductionMode                                  = 0x0059,
+    SYMetadataExifFlash_FlashFiredAutoModeReturnLightNotDetectedRedEyeReductionMode            = 0x005D,
+    SYMetadataExifFlash_FlashFiredAutoModeReturnLightDetectedRedEyeReductionMode               = 0x005F,
+} SYMetadataExifFlash;
+
+@interface SYMetadataExif : SYMetadataBase
+
+@property SYMETADATA_PROPERTY_COPY NSNumber              *exposureTime;
+@property SYMETADATA_PROPERTY_COPY NSNumber              *fNumber;
+@property SYMETADATA_PROPERTY_COPY NSNumber              *exposureProgram;
+@property SYMETADATA_PROPERTY_COPY NSString              *spectralSensitivity;
+@property SYMETADATA_PROPERTY_COPY NSArray <NSNumber *>  *isoSpeedRatings;
+@property SYMETADATA_PROPERTY_COPY NSObject              *oecf;
+@property SYMETADATA_PROPERTY_COPY NSArray <NSNumber *>  *version;
+@property SYMETADATA_PROPERTY_COPY NSString              *dateTimeOriginal;
+@property SYMETADATA_PROPERTY_COPY NSString              *dateTimeDigitized;
+@property SYMETADATA_PROPERTY_COPY NSArray <NSNumber *>  *componentsConfiguration;
+@property SYMETADATA_PROPERTY_COPY NSNumber              *compressedBitsPerPixel;
+@property SYMETADATA_PROPERTY_COPY NSNumber              *shutterSpeedValue;
+@property SYMETADATA_PROPERTY_COPY NSNumber              *apertureValue;
+@property SYMETADATA_PROPERTY_COPY NSNumber              *brightnessValue;
+@property SYMETADATA_PROPERTY_COPY NSNumber              *exposureBiasValue;
+@property SYMETADATA_PROPERTY_COPY NSNumber              *maxApertureValue;
+@property SYMETADATA_PROPERTY_COPY NSNumber              *subjectDistance;
+@property SYMETADATA_PROPERTY_COPY NSNumber              *meteringMode;
+@property SYMETADATA_PROPERTY_COPY NSNumber              *lightSource;
+@property SYMETADATA_PROPERTY_COPY NSNumber              *flash;
+@property SYMETADATA_PROPERTY_COPY NSString              *flashString;
+@property SYMETADATA_PROPERTY_COPY NSNumber              *focalLength;
+@property SYMETADATA_PROPERTY_COPY NSArray <NSNumber *>  *subjectArea;
+@property SYMETADATA_PROPERTY_COPY NSObject              *makerNote;
+@property SYMETADATA_PROPERTY_COPY NSString              *userComment;
+@property SYMETADATA_PROPERTY_COPY NSString              *subsecTime;
+@property SYMETADATA_PROPERTY_COPY NSString              *subsecTimeOriginal;
+@property SYMETADATA_PROPERTY_COPY NSString              *subsecTimeDigitized;
+@property SYMETADATA_PROPERTY_COPY NSArray <NSNumber *>  *flashPixVersion;
+@property SYMETADATA_PROPERTY_COPY NSNumber              *colorSpace;
+@property SYMETADATA_PROPERTY_COPY NSNumber              *pixelXDimension;
+@property SYMETADATA_PROPERTY_COPY NSNumber              *pixelYDimension;
+@property SYMETADATA_PROPERTY_COPY NSString              *relatedSoundFile;
+@property SYMETADATA_PROPERTY_COPY NSNumber              *flashEnergy;
+@property SYMETADATA_PROPERTY_COPY NSObject              *spatialFrequencyResponse;
+@property SYMETADATA_PROPERTY_COPY NSNumber              *focalPlaneXResolution;
+@property SYMETADATA_PROPERTY_COPY NSNumber              *focalPlaneYResolution;
+@property SYMETADATA_PROPERTY_COPY NSNumber              *focalPlaneResolutionUnit;
+@property SYMETADATA_PROPERTY_COPY NSArray <NSNumber *>  *subjectLocation;
+@property SYMETADATA_PROPERTY_COPY NSNumber              *exposureIndex;
+@property SYMETADATA_PROPERTY_COPY NSNumber              *sensingMethod;
+@property SYMETADATA_PROPERTY_COPY NSObject              *fileSource;
+@property SYMETADATA_PROPERTY_COPY NSObject              *sceneType;
+@property SYMETADATA_PROPERTY_COPY NSArray               *cfaPattern;
+@property SYMETADATA_PROPERTY_COPY NSNumber              *customRendered;
+@property SYMETADATA_PROPERTY_COPY NSNumber              *exposureMode;
+@property SYMETADATA_PROPERTY_COPY NSNumber              *whiteBalance;
+@property SYMETADATA_PROPERTY_COPY NSNumber              *digitalZoomRatio;
+@property SYMETADATA_PROPERTY_COPY NSNumber              *focalLenIn35mmFilm;
+@property SYMETADATA_PROPERTY_COPY NSNumber              *sceneCaptureType;
+@property SYMETADATA_PROPERTY_COPY NSNumber              *gainControl;
+@property SYMETADATA_PROPERTY_COPY NSNumber              *contrast;
+@property SYMETADATA_PROPERTY_COPY NSNumber              *saturation;
+@property SYMETADATA_PROPERTY_COPY NSNumber              *sharpness;
+@property SYMETADATA_PROPERTY_COPY NSObject              *deviceSettingDescription;
+@property SYMETADATA_PROPERTY_COPY NSNumber              *subjectDistRange;
+@property SYMETADATA_PROPERTY_COPY NSString              *imageUniqueID;
+@property SYMETADATA_PROPERTY_COPY NSString              *cameraOwnerName;
+@property SYMETADATA_PROPERTY_COPY NSString              *bodySerialNumber;
+@property SYMETADATA_PROPERTY_COPY NSArray               *lensSpecification;
+@property SYMETADATA_PROPERTY_COPY NSString              *lensMake;
+@property SYMETADATA_PROPERTY_COPY NSString              *lensModel;
+@property SYMETADATA_PROPERTY_COPY NSString              *lensSerialNumber;
+@property SYMETADATA_PROPERTY_COPY NSNumber              *gamma;
+@property SYMETADATA_PROPERTY_COPY NSNumber              *sensitivityType;
+@property SYMETADATA_PROPERTY_COPY NSNumber              *standardOutputSensitivity;
+@property SYMETADATA_PROPERTY_COPY NSNumber              *recommendedExposureIndex;
+@property SYMETADATA_PROPERTY_COPY NSNumber              *isoSpeed;
+@property SYMETADATA_PROPERTY_COPY NSNumber              *isoSpeedLatitudeyyy;
+@property SYMETADATA_PROPERTY_COPY NSNumber              *isoSpeedLatitudezzz;
+
+@end
+
+

--- a/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadataExif.m
+++ b/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadataExif.m
@@ -1,0 +1,88 @@
+//
+//SYMetadataEXIF.m
+//SYPictureMetadataExample
+//
+//Created by Stan Chevallier on 12/13/12.
+//Copyright (c2012 Syan. All rights reserved.
+//
+
+#import "SYMetadataEXIF.h"
+#import <ImageIO/ImageIO.h>
+
+@implementation SYMetadataExif
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey
+{
+    return @{SYStringSel(exposureTime):             (NSString *)kCGImagePropertyExifExposureTime,
+             SYStringSel(fNumber):                  (NSString *)kCGImagePropertyExifFNumber,
+             SYStringSel(exposureProgram):          (NSString *)kCGImagePropertyExifExposureProgram,
+             SYStringSel(spectralSensitivity):      (NSString *)kCGImagePropertyExifSpectralSensitivity,
+             SYStringSel(isoSpeedRatings):          (NSString *)kCGImagePropertyExifISOSpeedRatings,
+             SYStringSel(oecf):                     (NSString *)kCGImagePropertyExifOECF,
+             SYStringSel(version):                  (NSString *)kCGImagePropertyExifVersion,
+             SYStringSel(dateTimeOriginal):         (NSString *)kCGImagePropertyExifDateTimeOriginal,
+             SYStringSel(dateTimeDigitized):        (NSString *)kCGImagePropertyExifDateTimeDigitized,
+             SYStringSel(componentsConfiguration):  (NSString *)kCGImagePropertyExifComponentsConfiguration,
+             SYStringSel(compressedBitsPerPixel):   (NSString *)kCGImagePropertyExifCompressedBitsPerPixel,
+             SYStringSel(shutterSpeedValue):        (NSString *)kCGImagePropertyExifShutterSpeedValue,
+             SYStringSel(apertureValue):            (NSString *)kCGImagePropertyExifApertureValue,
+             SYStringSel(brightnessValue):          (NSString *)kCGImagePropertyExifBrightnessValue,
+             SYStringSel(exposureBiasValue):        (NSString *)kCGImagePropertyExifExposureBiasValue,
+             SYStringSel(maxApertureValue):         (NSString *)kCGImagePropertyExifMaxApertureValue,
+             SYStringSel(subjectDistance):          (NSString *)kCGImagePropertyExifSubjectDistance,
+             SYStringSel(meteringMode):             (NSString *)kCGImagePropertyExifMeteringMode,
+             SYStringSel(lightSource):              (NSString *)kCGImagePropertyExifLightSource,
+             SYStringSel(flash):                    (NSString *)kCGImagePropertyExifFlash,
+             SYStringSel(focalLength):              (NSString *)kCGImagePropertyExifFocalLength,
+             SYStringSel(subjectArea):              (NSString *)kCGImagePropertyExifSubjectArea,
+             SYStringSel(makerNote):                (NSString *)kCGImagePropertyExifMakerNote,
+             SYStringSel(userComment):              (NSString *)kCGImagePropertyExifUserComment,
+             SYStringSel(subsecTime):               (NSString *)kCGImagePropertyExifSubsecTime,
+             SYStringSel(subsecTimeOriginal):       (NSString *)kCGImagePropertyExifSubsecTimeOrginal,
+             SYStringSel(subsecTimeDigitized):      (NSString *)kCGImagePropertyExifSubsecTimeDigitized,
+             SYStringSel(flashPixVersion):          (NSString *)kCGImagePropertyExifFlashPixVersion,
+             SYStringSel(colorSpace):               (NSString *)kCGImagePropertyExifColorSpace,
+             SYStringSel(pixelXDimension):          (NSString *)kCGImagePropertyExifPixelXDimension,
+             SYStringSel(pixelYDimension):          (NSString *)kCGImagePropertyExifPixelYDimension,
+             SYStringSel(relatedSoundFile):         (NSString *)kCGImagePropertyExifRelatedSoundFile,
+             SYStringSel(flashEnergy):              (NSString *)kCGImagePropertyExifFlashEnergy,
+             SYStringSel(spatialFrequencyResponse): (NSString *)kCGImagePropertyExifSpatialFrequencyResponse,
+             SYStringSel(focalPlaneXResolution):    (NSString *)kCGImagePropertyExifFocalPlaneXResolution,
+             SYStringSel(focalPlaneYResolution):    (NSString *)kCGImagePropertyExifFocalPlaneYResolution,
+             SYStringSel(focalPlaneResolutionUnit): (NSString *)kCGImagePropertyExifFocalPlaneResolutionUnit,
+             SYStringSel(subjectLocation):          (NSString *)kCGImagePropertyExifSubjectLocation,
+             SYStringSel(exposureIndex):            (NSString *)kCGImagePropertyExifExposureIndex,
+             SYStringSel(sensingMethod):            (NSString *)kCGImagePropertyExifSensingMethod,
+             SYStringSel(fileSource):               (NSString *)kCGImagePropertyExifFileSource,
+             SYStringSel(sceneType):                (NSString *)kCGImagePropertyExifSceneType,
+             SYStringSel(cfaPattern):               (NSString *)kCGImagePropertyExifCFAPattern,
+             SYStringSel(customRendered):           (NSString *)kCGImagePropertyExifCustomRendered,
+             SYStringSel(exposureMode):             (NSString *)kCGImagePropertyExifExposureMode,
+             SYStringSel(whiteBalance):             (NSString *)kCGImagePropertyExifWhiteBalance,
+             SYStringSel(digitalZoomRatio):         (NSString *)kCGImagePropertyExifDigitalZoomRatio,
+             SYStringSel(focalLenIn35mmFilm):       (NSString *)kCGImagePropertyExifFocalLenIn35mmFilm,
+             SYStringSel(sceneCaptureType):         (NSString *)kCGImagePropertyExifSceneCaptureType,
+             SYStringSel(gainControl):              (NSString *)kCGImagePropertyExifGainControl,
+             SYStringSel(contrast):                 (NSString *)kCGImagePropertyExifContrast,
+             SYStringSel(saturation):               (NSString *)kCGImagePropertyExifSaturation,
+             SYStringSel(sharpness):                (NSString *)kCGImagePropertyExifSharpness,
+             SYStringSel(deviceSettingDescription): (NSString *)kCGImagePropertyExifDeviceSettingDescription,
+             SYStringSel(subjectDistRange):         (NSString *)kCGImagePropertyExifSubjectDistRange,
+             SYStringSel(imageUniqueID):            (NSString *)kCGImagePropertyExifImageUniqueID,
+             SYStringSel(cameraOwnerName):          (NSString *)kCGImagePropertyExifCameraOwnerName,
+             SYStringSel(bodySerialNumber):         (NSString *)kCGImagePropertyExifBodySerialNumber,
+             SYStringSel(lensSpecification):        (NSString *)kCGImagePropertyExifLensSpecification,
+             SYStringSel(lensMake):                 (NSString *)kCGImagePropertyExifLensMake,
+             SYStringSel(lensModel):                (NSString *)kCGImagePropertyExifLensModel,
+             SYStringSel(lensSerialNumber):         (NSString *)kCGImagePropertyExifLensSerialNumber,
+             SYStringSel(gamma):                    (NSString *)kCGImagePropertyExifGamma,
+             SYStringSel(sensitivityType):          (NSString *)kCGImagePropertyExifSensitivityType,
+             SYStringSel(standardOutputSensitivity):(NSString *)kCGImagePropertyExifStandardOutputSensitivity,
+             SYStringSel(recommendedExposureIndex): (NSString *)kCGImagePropertyExifRecommendedExposureIndex,
+             SYStringSel(isoSpeed):                 (NSString *)kCGImagePropertyExifISOSpeed,
+             SYStringSel(isoSpeedLatitudeyyy):      (NSString *)kCGImagePropertyExifISOSpeedLatitudeyyy,
+             SYStringSel(isoSpeedLatitudezzz):      (NSString *)kCGImagePropertyExifISOSpeedLatitudezzz,
+             };
+}
+
+@end

--- a/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadataExifAux.h
+++ b/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadataExifAux.h
@@ -1,0 +1,27 @@
+//
+//  SYMetadataExifAux.h
+//  SYPictureMetadataExample
+//
+//  Created by Stan Chevallier on 12/16/12.
+//  Copyright (c) 2012 Syan. All rights reserved.
+//
+
+#import "SYMetadataBase.h"
+
+@interface SYMetadataExifAux : SYMetadataBase
+
+@property SYMETADATA_PROPERTY_COPY NSArray <NSNumber *>  *lensInfo;
+@property SYMETADATA_PROPERTY_COPY NSString              *lensModel;
+@property SYMETADATA_PROPERTY_COPY NSString              *serialNumber;
+@property SYMETADATA_PROPERTY_COPY NSNumber              *lensID;
+@property SYMETADATA_PROPERTY_COPY NSString              *lensSerialNumber;
+@property SYMETADATA_PROPERTY_COPY NSNumber              *imageNumber;
+@property SYMETADATA_PROPERTY_COPY NSObject              *flashCompensation;
+@property SYMETADATA_PROPERTY_COPY NSString              *ownerName;
+@property SYMETADATA_PROPERTY_COPY NSObject              *firmware;
+@property SYMETADATA_PROPERTY_COPY NSNumber              *focusMode;
+@property SYMETADATA_PROPERTY_COPY NSNumber              *focusDistance;
+@property SYMETADATA_PROPERTY_COPY NSArray               *afInfo;
+@property SYMETADATA_PROPERTY_COPY NSNumber              *imageStabilization;
+
+@end

--- a/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadataExifAux.m
+++ b/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadataExifAux.m
@@ -1,0 +1,35 @@
+//
+//  SYMetadataExifAux.m
+//  SYPictureMetadataExample
+//
+//  Created by Stan Chevallier on 12/16/12.
+//  Copyright (c 2012 Syan. All rights reserved.
+//
+
+#import <ImageIO/ImageIO.h>
+#import "SYMetadataExifAux.h"
+
+@implementation SYMetadataExifAux
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey
+{
+    return @{SYStringSel(lensInfo):             (NSString *)kCGImagePropertyExifAuxLensInfo,
+             SYStringSel(lensModel):            (NSString *)kCGImagePropertyExifAuxLensModel,
+             SYStringSel(serialNumber):         (NSString *)kCGImagePropertyExifAuxSerialNumber,
+             SYStringSel(lensID):               (NSString *)kCGImagePropertyExifAuxLensID,
+             SYStringSel(lensSerialNumber):     (NSString *)kCGImagePropertyExifAuxLensSerialNumber,
+             SYStringSel(imageNumber):          (NSString *)kCGImagePropertyExifAuxImageNumber,
+             SYStringSel(flashCompensation):    (NSString *)kCGImagePropertyExifAuxFlashCompensation,
+             SYStringSel(ownerName):            (NSString *)kCGImagePropertyExifAuxOwnerName,
+             SYStringSel(firmware):             (NSString *)kCGImagePropertyExifAuxFirmware,
+             
+             // iOS reads the data but the keys are not publicly declared, we use the Nikon equivalents
+             SYStringSel(focusMode):            (NSString *)kCGImagePropertyMakerNikonFocusMode,
+             SYStringSel(focusDistance):        (NSString *)kCGImagePropertyMakerNikonFocusDistance,
+             
+             SYStringSel(afInfo):               (NSString *)kSYImagePropertyExifAuxAutoFocusInfo,
+             SYStringSel(imageStabilization):   (NSString *)kSYImagePropertyExifAuxImageStabilization,
+             };
+}
+
+@end

--- a/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadataGIF.h
+++ b/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadataGIF.h
@@ -1,0 +1,19 @@
+//
+//  SYMetadataGIF.h
+//  SYPictureMetadataExample
+//
+//  Created by Stan Chevallier on 12/16/12.
+//  Copyright (c) 2012 Syan. All rights reserved.
+//
+
+#import "SYMetadataBase.h"
+
+@interface SYMetadataGIF : SYMetadataBase
+
+@property SYMETADATA_PROPERTY_COPY   NSNumber                *loopCount;
+@property SYMETADATA_PROPERTY_COPY   NSNumber                *delayTime;
+@property SYMETADATA_PROPERTY_COPY   NSArray <NSNumber *>    *imageColorMap;
+@property SYMETADATA_PROPERTY_COPY   NSNumber                *hasGlobalColorMap;
+@property SYMETADATA_PROPERTY_COPY   NSNumber                *unclampedDelayTime;
+
+@end

--- a/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadataGIF.m
+++ b/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadataGIF.m
@@ -1,0 +1,24 @@
+//
+//  SYMetadataGIF.m
+//  SYPictureMetadataExample
+//
+//  Created by Stan Chevallier on 12/16/12.
+//  Copyright (c) 2012 Syan. All rights reserved.
+//
+
+#import "SYMetadataGIF.h"
+#import <ImageIO/ImageIO.h>
+
+@implementation SYMetadataGIF
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey
+{
+    return @{SYStringSel(loopCount):            (NSString *)kCGImagePropertyGIFLoopCount,
+             SYStringSel(delayTime):            (NSString *)kCGImagePropertyGIFDelayTime,
+             SYStringSel(imageColorMap):        (NSString *)kCGImagePropertyGIFImageColorMap,
+             SYStringSel(hasGlobalColorMap):    (NSString *)kCGImagePropertyGIFHasGlobalColorMap,
+             SYStringSel(unclampedDelayTime):   (NSString *)kCGImagePropertyGIFUnclampedDelayTime,
+             };
+}
+
+@end

--- a/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadataGPS.h
+++ b/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadataGPS.h
@@ -1,0 +1,48 @@
+//
+//  SYMetadataGPS.h
+//  SYPictureMetadataExample
+//
+//  Created by Stan Chevallier on 12/16/12.
+//  Copyright (c) 2012 Syan. All rights reserved.
+//
+
+#import "SYMetadataBase.h"
+
+// TODO: use enum for refs instead of strings
+
+@interface SYMetadataGPS : SYMetadataBase
+
+@property SYMETADATA_PROPERTY_COPY NSArray <NSNumber *>  *version;
+@property SYMETADATA_PROPERTY_COPY NSString  *latitudeRef;
+@property SYMETADATA_PROPERTY_COPY NSNumber  *latitude;
+@property SYMETADATA_PROPERTY_COPY NSString  *longitudeRef;
+@property SYMETADATA_PROPERTY_COPY NSNumber  *longitude;
+@property SYMETADATA_PROPERTY_COPY NSNumber  *altitudeRef;
+@property SYMETADATA_PROPERTY_COPY NSNumber  *altitude;
+@property SYMETADATA_PROPERTY_COPY NSString  *timeStamp;
+@property SYMETADATA_PROPERTY_COPY NSString  *satellites;
+@property SYMETADATA_PROPERTY_COPY NSString  *status;
+@property SYMETADATA_PROPERTY_COPY NSString  *measureMode;
+@property SYMETADATA_PROPERTY_COPY NSNumber  *dop;
+@property SYMETADATA_PROPERTY_COPY NSString  *speedRef;
+@property SYMETADATA_PROPERTY_COPY NSNumber  *speed;
+@property SYMETADATA_PROPERTY_COPY NSString  *trackRef;
+@property SYMETADATA_PROPERTY_COPY NSNumber  *track;
+@property SYMETADATA_PROPERTY_COPY NSString  *imgDirectionRef;
+@property SYMETADATA_PROPERTY_COPY NSNumber  *imgDirection;
+@property SYMETADATA_PROPERTY_COPY NSString  *mapDatum;
+@property SYMETADATA_PROPERTY_COPY NSString  *destLatitudeRef;
+@property SYMETADATA_PROPERTY_COPY NSNumber  *destLatitude;
+@property SYMETADATA_PROPERTY_COPY NSString  *destLongitudeRef;
+@property SYMETADATA_PROPERTY_COPY NSNumber  *destLongitude;
+@property SYMETADATA_PROPERTY_COPY NSString  *destBearingRef;
+@property SYMETADATA_PROPERTY_COPY NSNumber  *destBearing;
+@property SYMETADATA_PROPERTY_COPY NSString  *destDistanceRef;
+@property SYMETADATA_PROPERTY_COPY NSNumber  *destDistance;
+@property SYMETADATA_PROPERTY_COPY NSString  *processingMethod;
+@property SYMETADATA_PROPERTY_COPY NSObject  *areaInformation;
+@property SYMETADATA_PROPERTY_COPY NSString  *dateStamp;
+@property SYMETADATA_PROPERTY_COPY NSNumber  *differental;
+@property SYMETADATA_PROPERTY_COPY NSNumber  *hPositioningError;
+
+@end

--- a/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadataGPS.m
+++ b/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadataGPS.m
@@ -1,0 +1,51 @@
+//
+//  SYMetadataGPS.m
+//  SYPictureMetadataExample
+//
+//  Created by Stan Chevallier on 12/16/12.
+//  Copyright (c) 2012 Syan. All rights reserved.
+//
+
+#import "SYMetadataGPS.h"
+#import <ImageIO/ImageIO.h>
+
+@implementation SYMetadataGPS
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey
+{
+    return @{SYStringSel(version):          (NSString *)kCGImagePropertyGPSVersion,
+             SYStringSel(latitudeRef):      (NSString *)kCGImagePropertyGPSLatitudeRef,
+             SYStringSel(latitude):         (NSString *)kCGImagePropertyGPSLatitude,
+             SYStringSel(longitudeRef):     (NSString *)kCGImagePropertyGPSLongitudeRef,
+             SYStringSel(longitude):        (NSString *)kCGImagePropertyGPSLongitude,
+             SYStringSel(altitudeRef):      (NSString *)kCGImagePropertyGPSAltitudeRef,
+             SYStringSel(altitude):         (NSString *)kCGImagePropertyGPSAltitude,
+             SYStringSel(timeStamp):        (NSString *)kCGImagePropertyGPSTimeStamp,
+             SYStringSel(satellites):       (NSString *)kCGImagePropertyGPSSatellites,
+             SYStringSel(status):           (NSString *)kCGImagePropertyGPSStatus,
+             SYStringSel(measureMode):      (NSString *)kCGImagePropertyGPSMeasureMode,
+             SYStringSel(dop):              (NSString *)kCGImagePropertyGPSDOP,
+             SYStringSel(speedRef):         (NSString *)kCGImagePropertyGPSSpeedRef,
+             SYStringSel(speed):            (NSString *)kCGImagePropertyGPSSpeed,
+             SYStringSel(trackRef):         (NSString *)kCGImagePropertyGPSTrackRef,
+             SYStringSel(track):            (NSString *)kCGImagePropertyGPSTrack,
+             SYStringSel(imgDirectionRef):  (NSString *)kCGImagePropertyGPSImgDirectionRef,
+             SYStringSel(imgDirection):     (NSString *)kCGImagePropertyGPSImgDirection,
+             SYStringSel(mapDatum):         (NSString *)kCGImagePropertyGPSMapDatum,
+             SYStringSel(destLatitudeRef):  (NSString *)kCGImagePropertyGPSDestLatitudeRef,
+             SYStringSel(destLatitude):     (NSString *)kCGImagePropertyGPSDestLatitude,
+             SYStringSel(destLongitudeRef): (NSString *)kCGImagePropertyGPSDestLongitudeRef,
+             SYStringSel(destLongitude):    (NSString *)kCGImagePropertyGPSDestLongitude,
+             SYStringSel(destBearingRef):   (NSString *)kCGImagePropertyGPSDestBearingRef,
+             SYStringSel(destBearing):      (NSString *)kCGImagePropertyGPSDestBearing,
+             SYStringSel(destDistanceRef):  (NSString *)kCGImagePropertyGPSDestDistanceRef,
+             SYStringSel(destDistance):     (NSString *)kCGImagePropertyGPSDestDistance,
+             SYStringSel(processingMethod): (NSString *)kCGImagePropertyGPSProcessingMethod,
+             SYStringSel(areaInformation):  (NSString *)kCGImagePropertyGPSAreaInformation,
+             SYStringSel(dateStamp):        (NSString *)kCGImagePropertyGPSDateStamp,
+             SYStringSel(differental):      (NSString *)kCGImagePropertyGPSDifferental,
+             SYStringSel(hPositioningError):(NSString *)kCGImagePropertyGPSHPositioningError,
+             };
+}
+
+@end

--- a/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadataIPTC.h
+++ b/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadataIPTC.h
@@ -1,0 +1,66 @@
+//
+//  SYMetadataIPTC.h
+//  SYPictureMetadataExample
+//
+//  Created by Stan Chevallier on 12/16/12.
+//  Copyright (c) 2012 Syan. All rights reserved.
+//
+
+#import "SYMetadataBase.h"
+#import "SYMetadataIPTCContactInfo.h"
+
+@interface SYMetadataIPTC : SYMetadataBase
+
+@property SYMETADATA_PROPERTY_COPY NSString              *objectTypeReference;
+@property SYMETADATA_PROPERTY_COPY NSArray <NSString *>  *objectAttributeReference;
+@property SYMETADATA_PROPERTY_COPY NSString              *objectName;
+@property SYMETADATA_PROPERTY_COPY NSString              *editStatus;
+@property SYMETADATA_PROPERTY_COPY NSString              *editorialUpdate;
+@property SYMETADATA_PROPERTY_COPY NSString              *urgency;
+@property SYMETADATA_PROPERTY_COPY NSArray <NSString *>  *subjectReference;
+@property SYMETADATA_PROPERTY_COPY NSString              *category;
+@property SYMETADATA_PROPERTY_COPY NSArray <NSString *>  *supplementalCategory;
+@property SYMETADATA_PROPERTY_COPY NSString              *fixtureIdentifier;
+@property SYMETADATA_PROPERTY_COPY NSArray <NSString *>  *keywords;
+@property SYMETADATA_PROPERTY_COPY NSArray <NSString *>  *contentLocationCode;
+@property SYMETADATA_PROPERTY_COPY NSArray <NSString *>  *contentLocationName;
+@property SYMETADATA_PROPERTY_COPY NSString              *releaseDate;
+@property SYMETADATA_PROPERTY_COPY NSString              *releaseTime;
+@property SYMETADATA_PROPERTY_COPY NSString              *expirationDate;
+@property SYMETADATA_PROPERTY_COPY NSString              *expirationTime;
+@property SYMETADATA_PROPERTY_COPY NSString              *specialInstructions;
+@property SYMETADATA_PROPERTY_COPY NSString              *actionAdvised;
+@property SYMETADATA_PROPERTY_COPY NSArray <NSString *>  *referenceService;
+@property SYMETADATA_PROPERTY_COPY NSArray <NSString *>  *referenceDate;
+@property SYMETADATA_PROPERTY_COPY NSArray <NSString *>  *referenceNumber;
+@property SYMETADATA_PROPERTY_COPY NSString              *dateCreated;
+@property SYMETADATA_PROPERTY_COPY NSString              *timeCreated;
+@property SYMETADATA_PROPERTY_COPY NSString              *digitalCreationDate;
+@property SYMETADATA_PROPERTY_COPY NSString              *digitalCreationTime;
+@property SYMETADATA_PROPERTY_COPY NSString              *originatingProgram;
+@property SYMETADATA_PROPERTY_COPY NSString              *programVersion;
+@property SYMETADATA_PROPERTY_COPY NSString              *objectCycle;
+@property SYMETADATA_PROPERTY_COPY NSArray <NSString *>  *byline;
+@property SYMETADATA_PROPERTY_COPY NSArray <NSString *>  *bylineTitle;
+@property SYMETADATA_PROPERTY_COPY NSString              *city;
+@property SYMETADATA_PROPERTY_COPY NSString              *subLocation;
+@property SYMETADATA_PROPERTY_COPY NSString              *provinceState;
+@property SYMETADATA_PROPERTY_COPY NSString              *countryPrimaryLocationCode;
+@property SYMETADATA_PROPERTY_COPY NSString              *countryPrimaryLocationName;
+@property SYMETADATA_PROPERTY_COPY NSString              *originalTransmissionReference;
+@property SYMETADATA_PROPERTY_COPY NSString              *headline;
+@property SYMETADATA_PROPERTY_COPY NSString              *credit;
+@property SYMETADATA_PROPERTY_COPY NSString              *source;
+@property SYMETADATA_PROPERTY_COPY NSString              *copyrightNotice;
+@property SYMETADATA_PROPERTY_COPY NSArray <NSString *>  *contact;
+@property SYMETADATA_PROPERTY_COPY NSString              *captionAbstract;
+@property SYMETADATA_PROPERTY_COPY NSArray <NSString *>  *writerEditor;
+@property SYMETADATA_PROPERTY_COPY NSString              *imageType;
+@property SYMETADATA_PROPERTY_COPY NSString              *imageOrientation;
+@property SYMETADATA_PROPERTY_COPY NSString              *languageIdentifier;
+@property SYMETADATA_PROPERTY_COPY NSNumber              *starRating;
+@property SYMETADATA_PROPERTY_COPY SYMetadataIPTCContactInfo *creatorContactInfo;
+@property SYMETADATA_PROPERTY_COPY NSString              *rightsUsageTerms;
+@property SYMETADATA_PROPERTY_COPY NSString              *scene;
+
+@end

--- a/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadataIPTC.m
+++ b/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadataIPTC.m
@@ -1,0 +1,80 @@
+//
+//  SYMetadataIPTC.m
+//  SYPictureMetadataExample
+//
+//  Created by Stan Chevallier on 12/16/12.
+//  Copyright (c) 2012 Syan. All rights reserved.
+//
+
+#import "SYMetadataIPTC.h"
+#import <ImageIO/ImageIO.h>
+
+@implementation SYMetadataIPTC
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey
+{
+    return @{SYStringSel(objectTypeReference):           (NSString *)kCGImagePropertyIPTCObjectTypeReference,
+             SYStringSel(objectAttributeReference):      (NSString *)kCGImagePropertyIPTCObjectAttributeReference,
+             SYStringSel(objectName):                    (NSString *)kCGImagePropertyIPTCObjectName,
+             SYStringSel(editStatus):                    (NSString *)kCGImagePropertyIPTCEditStatus,
+             SYStringSel(editorialUpdate):               (NSString *)kCGImagePropertyIPTCEditorialUpdate,
+             SYStringSel(urgency):                       (NSString *)kCGImagePropertyIPTCUrgency,
+             SYStringSel(subjectReference):              (NSString *)kCGImagePropertyIPTCSubjectReference,
+             SYStringSel(category):                      (NSString *)kCGImagePropertyIPTCCategory,
+             SYStringSel(supplementalCategory):          (NSString *)kCGImagePropertyIPTCSupplementalCategory,
+             SYStringSel(fixtureIdentifier):             (NSString *)kCGImagePropertyIPTCFixtureIdentifier,
+             SYStringSel(keywords):                      (NSString *)kCGImagePropertyIPTCKeywords,
+             SYStringSel(contentLocationCode):           (NSString *)kCGImagePropertyIPTCContentLocationCode,
+             SYStringSel(contentLocationName):           (NSString *)kCGImagePropertyIPTCContentLocationName,
+             SYStringSel(releaseDate):                   (NSString *)kCGImagePropertyIPTCReleaseDate,
+             SYStringSel(releaseTime):                   (NSString *)kCGImagePropertyIPTCReleaseTime,
+             SYStringSel(expirationDate):                (NSString *)kCGImagePropertyIPTCExpirationDate,
+             SYStringSel(expirationTime):                (NSString *)kCGImagePropertyIPTCExpirationTime,
+             SYStringSel(specialInstructions):           (NSString *)kCGImagePropertyIPTCSpecialInstructions,
+             SYStringSel(actionAdvised):                 (NSString *)kCGImagePropertyIPTCActionAdvised,
+             SYStringSel(referenceService):              (NSString *)kCGImagePropertyIPTCReferenceService,
+             SYStringSel(referenceDate):                 (NSString *)kCGImagePropertyIPTCReferenceDate,
+             SYStringSel(referenceNumber):               (NSString *)kCGImagePropertyIPTCReferenceNumber,
+             SYStringSel(dateCreated):                   (NSString *)kCGImagePropertyIPTCDateCreated,
+             SYStringSel(timeCreated):                   (NSString *)kCGImagePropertyIPTCTimeCreated,
+             SYStringSel(digitalCreationDate):           (NSString *)kCGImagePropertyIPTCDigitalCreationDate,
+             SYStringSel(digitalCreationTime):           (NSString *)kCGImagePropertyIPTCDigitalCreationTime,
+             SYStringSel(originatingProgram):            (NSString *)kCGImagePropertyIPTCOriginatingProgram,
+             SYStringSel(programVersion):                (NSString *)kCGImagePropertyIPTCProgramVersion,
+             SYStringSel(objectCycle):                   (NSString *)kCGImagePropertyIPTCObjectCycle,
+             SYStringSel(byline):                        (NSString *)kCGImagePropertyIPTCByline,
+             SYStringSel(bylineTitle):                   (NSString *)kCGImagePropertyIPTCBylineTitle,
+             SYStringSel(city):                          (NSString *)kCGImagePropertyIPTCCity,
+             SYStringSel(subLocation):                   (NSString *)kCGImagePropertyIPTCSubLocation,
+             SYStringSel(provinceState):                 (NSString *)kCGImagePropertyIPTCProvinceState,
+             SYStringSel(countryPrimaryLocationCode):    (NSString *)kCGImagePropertyIPTCCountryPrimaryLocationCode,
+             SYStringSel(countryPrimaryLocationName):    (NSString *)kCGImagePropertyIPTCCountryPrimaryLocationName,
+             SYStringSel(originalTransmissionReference): (NSString *)kCGImagePropertyIPTCOriginalTransmissionReference,
+             SYStringSel(headline):                      (NSString *)kCGImagePropertyIPTCHeadline,
+             SYStringSel(credit):                        (NSString *)kCGImagePropertyIPTCCredit,
+             SYStringSel(source):                        (NSString *)kCGImagePropertyIPTCSource,
+             SYStringSel(copyrightNotice):               (NSString *)kCGImagePropertyIPTCCopyrightNotice,
+             SYStringSel(contact):                       (NSString *)kCGImagePropertyIPTCContact,
+             SYStringSel(captionAbstract):               (NSString *)kCGImagePropertyIPTCCaptionAbstract,
+             SYStringSel(writerEditor):                  (NSString *)kCGImagePropertyIPTCWriterEditor,
+             SYStringSel(imageType):                     (NSString *)kCGImagePropertyIPTCImageType,
+             SYStringSel(imageOrientation):              (NSString *)kCGImagePropertyIPTCImageOrientation,
+             SYStringSel(languageIdentifier):            (NSString *)kCGImagePropertyIPTCLanguageIdentifier,
+             SYStringSel(starRating):                    (NSString *)kCGImagePropertyIPTCStarRating,
+             SYStringSel(creatorContactInfo):            (NSString *)kCGImagePropertyIPTCCreatorContactInfo,
+             SYStringSel(rightsUsageTerms):              (NSString *)kCGImagePropertyIPTCRightsUsageTerms,
+             SYStringSel(scene):                         (NSString *)kCGImagePropertyIPTCScene,
+             };
+}
+
++ (NSValueTransformer *)JSONTransformerForKey:(NSString *)key
+{
+    if ([key isEqualToString:SYStringSel(creatorContactInfo)])
+    {
+        return [NSValueTransformer sy_dictionaryTransformerForModelOfClass:[SYMetadataIPTCContactInfo class]];
+    }
+    
+    return [super JSONTransformerForKey:key];
+}
+
+@end

--- a/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadataIPTCContactInfo.h
+++ b/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadataIPTCContactInfo.h
@@ -1,0 +1,22 @@
+//
+//  SYMetadataIPTCContactInfo.h
+//  SYPictureMetadataExample
+//
+//  Created by Stan Chevallier on 12/16/12.
+//  Copyright (c) 2012 Syan. All rights reserved.
+//
+
+#import "SYMetadataBase.h"
+
+@interface SYMetadataIPTCContactInfo : SYMetadataBase
+
+@property SYMETADATA_PROPERTY_COPY NSString  *city;
+@property SYMETADATA_PROPERTY_COPY NSString  *country;
+@property SYMETADATA_PROPERTY_COPY NSString  *address;
+@property SYMETADATA_PROPERTY_COPY NSString  *postalCode;
+@property SYMETADATA_PROPERTY_COPY NSString  *stateProvince;
+@property SYMETADATA_PROPERTY_COPY NSString  *emails;
+@property SYMETADATA_PROPERTY_COPY NSString  *phones;
+@property SYMETADATA_PROPERTY_COPY NSString  *webURLs;
+
+@end

--- a/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadataIPTCContactInfo.m
+++ b/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadataIPTCContactInfo.m
@@ -1,0 +1,27 @@
+//
+//  SYMetadataIPTCContactInfo.m
+//  SYPictureMetadataExample
+//
+//  Created by Stan Chevallier on 12/16/12.
+//  Copyright (c) 2012 Syan. All rights reserved.
+//
+
+#import "SYMetadataIPTCContactInfo.h"
+#import <ImageIO/ImageIO.h>
+
+@implementation SYMetadataIPTCContactInfo
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey
+{
+    return @{SYStringSel(city):         (NSString *)kCGImagePropertyIPTCContactInfoCity,
+             SYStringSel(country):      (NSString *)kCGImagePropertyIPTCContactInfoCountry,
+             SYStringSel(address):      (NSString *)kCGImagePropertyIPTCContactInfoAddress,
+             SYStringSel(postalCode):   (NSString *)kCGImagePropertyIPTCContactInfoPostalCode,
+             SYStringSel(stateProvince):(NSString *)kCGImagePropertyIPTCContactInfoStateProvince,
+             SYStringSel(emails):       (NSString *)kCGImagePropertyIPTCContactInfoEmails,
+             SYStringSel(phones):       (NSString *)kCGImagePropertyIPTCContactInfoPhones,
+             SYStringSel(webURLs):      (NSString *)kCGImagePropertyIPTCContactInfoWebURLs,
+             };
+}
+
+@end

--- a/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadataJFIF.h
+++ b/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadataJFIF.h
@@ -1,0 +1,19 @@
+//
+//  SYMetadataJFIF.h
+//  SYPictureMetadataExample
+//
+//  Created by Stan Chevallier on 12/16/12.
+//  Copyright (c) 2012 Syan. All rights reserved.
+//
+
+#import "SYMetadataBase.h"
+
+@interface SYMetadataJFIF : SYMetadataBase
+
+@property SYMETADATA_PROPERTY_COPY NSArray     *version;
+@property SYMETADATA_PROPERTY_COPY NSNumber    *xDensity;
+@property SYMETADATA_PROPERTY_COPY NSNumber    *yDensity;
+@property SYMETADATA_PROPERTY_COPY NSNumber    *densityUnit;
+@property SYMETADATA_PROPERTY_COPY NSNumber    *isProgressive;
+
+@end

--- a/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadataJFIF.m
+++ b/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadataJFIF.m
@@ -1,0 +1,24 @@
+//
+//  SYMetadataJFIF.m
+//  SYPictureMetadataExample
+//
+//  Created by Stan Chevallier on 12/16/12.
+//  Copyright (c) 2012 Syan. All rights reserved.
+//
+
+#import "SYMetadataJFIF.h"
+#import <ImageIO/ImageIO.h>
+
+@implementation SYMetadataJFIF
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey
+{
+    return @{SYStringSel(version):      (NSString *)kCGImagePropertyJFIFVersion,
+             SYStringSel(xDensity):     (NSString *)kCGImagePropertyJFIFXDensity,
+             SYStringSel(yDensity):     (NSString *)kCGImagePropertyJFIFYDensity,
+             SYStringSel(densityUnit):  (NSString *)kCGImagePropertyJFIFDensityUnit,
+             SYStringSel(isProgressive):(NSString *)kCGImagePropertyJFIFIsProgressive,
+             };
+}
+
+@end

--- a/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadataMakerCanon.h
+++ b/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadataMakerCanon.h
@@ -1,0 +1,38 @@
+//
+//  SYMetadataMakerCanon.h
+//  SYPictureMetadataExample
+//
+//  Created by Stan Chevallier on 12/16/12.
+//  Copyright (c) 2012 Syan. All rights reserved.
+//
+
+#import "SYMetadataBase.h"
+
+typedef enum : NSUInteger {
+   SYMetadataMakerCanonContinuousDriver_Single                  = 0,
+   SYMetadataMakerCanonContinuousDriver_Continuous              = 1,
+   SYMetadataMakerCanonContinuousDriver_Movie                   = 2,
+   SYMetadataMakerCanonContinuousDriver_ContinuousSpeedPriority = 3,
+   SYMetadataMakerCanonContinuousDriver_ContinuousLow           = 4,
+   SYMetadataMakerCanonContinuousDriver_ContinuousHigh          = 5,
+   SYMetadataMakerCanonContinuousDriver_SilentSingle            = 6,
+   SYMetadataMakerCanonContinuousDriver_SingleSilent            = 9,
+   SYMetadataMakerCanonContinuousDriver_ContinuousSilent        = 10,
+} SYMetadataMakerCanonContinuousDriver;
+
+@interface SYMetadataMakerCanon : SYMetadataBase
+
+@property SYMETADATA_PROPERTY_COPY NSString  *ownerName;
+@property SYMETADATA_PROPERTY_COPY NSNumber  *cameraSerialNumber;
+@property SYMETADATA_PROPERTY_COPY NSNumber  *imageSerialNumber;
+@property SYMETADATA_PROPERTY_COPY NSNumber  *flashExposureComp;
+@property SYMETADATA_PROPERTY_COPY NSNumber  *continuousDrive;
+@property SYMETADATA_PROPERTY_COPY NSString  *lensModel;
+@property SYMETADATA_PROPERTY_COPY NSString  *firmware;
+@property SYMETADATA_PROPERTY_COPY NSNumber  *aspectRatioInfo;
+@property SYMETADATA_PROPERTY_COPY NSNumber  *whiteBalanceIndex;
+@property SYMETADATA_PROPERTY_COPY NSNumber  *uniqueModelID;
+@property SYMETADATA_PROPERTY_COPY NSNumber  *maxAperture;
+@property SYMETADATA_PROPERTY_COPY NSNumber  *minAperture;
+
+@end

--- a/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadataMakerCanon.m
+++ b/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadataMakerCanon.m
@@ -1,0 +1,35 @@
+//
+//  SYMetadataMakerCanon.m
+//  SYPictureMetadataExample
+//
+//  Created by Stan Chevallier on 12/16/12.
+//  Copyright (c) 2012 Syan. All rights reserved.
+//
+
+#import "SYMetadataMakerCanon.h"
+#import <ImageIO/ImageIO.h>
+
+@implementation SYMetadataMakerCanon
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey
+{
+    return @{SYStringSel(ownerName):            (NSString *)kCGImagePropertyMakerCanonOwnerName,
+             SYStringSel(cameraSerialNumber):   (NSString *)kCGImagePropertyMakerCanonCameraSerialNumber,
+             SYStringSel(imageSerialNumber):    (NSString *)kCGImagePropertyMakerCanonImageSerialNumber,
+             SYStringSel(flashExposureComp):    (NSString *)kCGImagePropertyMakerCanonFlashExposureComp,
+             SYStringSel(continuousDrive):      (NSString *)kCGImagePropertyMakerCanonContinuousDrive,
+             SYStringSel(lensModel):            (NSString *)kCGImagePropertyMakerCanonLensModel,
+             SYStringSel(firmware):             (NSString *)kCGImagePropertyMakerCanonFirmware,
+             SYStringSel(aspectRatioInfo):      (NSString *)kCGImagePropertyMakerCanonAspectRatioInfo,
+             
+             // data is read by iOS but is not accessible via a publicly declared key. we use the one from CIFF
+             SYStringSel(whiteBalanceIndex):    (NSString *)kCGImagePropertyCIFFWhiteBalanceIndex,
+             
+             SYStringSel(maxAperture):          (NSString *)kSYImagePropertyCIFFMaxAperture,
+             SYStringSel(minAperture):          (NSString *)kSYImagePropertyCIFFMinAperture,
+             SYStringSel(uniqueModelID):        (NSString *)kSYImagePropertyCIFFUniqueModelID,
+             };
+}
+
+@end
+

--- a/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadataMakerFuji.h
+++ b/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadataMakerFuji.h
@@ -1,0 +1,13 @@
+//
+//  SYMetadataMakerFuji.h
+//  SYPictureMetadataExample
+//
+//  Created by Stan Chevallier on 12/16/12.
+//  Copyright (c) 2012 Syan. All rights reserved.
+//
+
+#import "SYMetadataBase.h"
+
+@interface SYMetadataMakerFuji : SYMetadataBase
+
+@end

--- a/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadataMakerFuji.m
+++ b/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadataMakerFuji.m
@@ -1,0 +1,13 @@
+//
+//  SYMetadataMakerFuji.m
+//  SYPictureMetadataExample
+//
+//  Created by Stan Chevallier on 12/16/12.
+//  Copyright (c) 2012 Syan. All rights reserved.
+//
+
+#import "SYMetadataMakerFuji.h"
+
+@implementation SYMetadataMakerFuji
+
+@end

--- a/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadataMakerMinolta.h
+++ b/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadataMakerMinolta.h
@@ -1,0 +1,13 @@
+//
+//  SYMetadataMakerMinolta.h
+//  SYPictureMetadataExample
+//
+//  Created by Stan Chevallier on 12/16/12.
+//  Copyright (c) 2012 Syan. All rights reserved.
+//
+
+#import "SYMetadataBase.h"
+
+@interface SYMetadataMakerMinolta : SYMetadataBase
+
+@end

--- a/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadataMakerMinolta.m
+++ b/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadataMakerMinolta.m
@@ -1,0 +1,13 @@
+//
+//  SYMetadataMakerMinolta.m
+//  SYPictureMetadataExample
+//
+//  Created by Stan Chevallier on 12/16/12.
+//  Copyright (c) 2012 Syan. All rights reserved.
+//
+
+#import "SYMetadataMakerMinolta.h"
+
+@implementation SYMetadataMakerMinolta
+
+@end

--- a/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadataMakerNikon.h
+++ b/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadataMakerNikon.h
@@ -1,0 +1,51 @@
+//
+//  SYMetadataMakerNikon.h
+//  SYPictureMetadataExample
+//
+//  Created by Stan Chevallier on 12/16/12.
+//  Copyright (c) 2012 Syan. All rights reserved.
+//
+
+#import "SYMetadataBase.h"
+
+typedef enum : NSUInteger {
+    SYMetadataMakerNikonShootingMode_Continuous             = 1 << 0L,
+    SYMetadataMakerNikonShootingMode_Delay                  = 1 << 1L,
+    SYMetadataMakerNikonShootingMode_PCControl              = 1 << 2L,
+    SYMetadataMakerNikonShootingMode_Selftimer              = 1 << 3L,
+    SYMetadataMakerNikonShootingMode_ExposureBracketing     = 1 << 4L,
+    SYMetadataMakerNikonShootingMode_AutoISO                = 1 << 5L,
+    SYMetadataMakerNikonShootingMode_WhiteBalanceBracketing = 1 << 6L,
+    SYMetadataMakerNikonShootingMode_IRControl              = 1 << 7L,
+    SYMetadataMakerNikonShootingMode_DLightingBracketing    = 1 << 8L,
+} SYMetadataMakerNikonShootingMode;
+
+typedef enum : NSUInteger {
+    SYMetadataMakerNikonLensType_MF = 1 << 0L,
+    SYMetadataMakerNikonLensType_D  = 1 << 1L,
+    SYMetadataMakerNikonLensType_G  = 1 << 2L,
+    SYMetadataMakerNikonLensType_VR = 1 << 3L,
+} SYMetadataMakerNikonLensType;
+
+@interface SYMetadataMakerNikon : SYMetadataBase
+
+@property SYMETADATA_PROPERTY_COPY NSArray <NSNumber *>  *isoSetting;
+@property SYMETADATA_PROPERTY_COPY NSString              *colorMode;
+@property SYMETADATA_PROPERTY_COPY NSString              *quality;
+@property SYMETADATA_PROPERTY_COPY NSString              *whiteBalanceMode;
+@property SYMETADATA_PROPERTY_COPY NSString              *sharpenMode;
+@property SYMETADATA_PROPERTY_COPY NSString              *focusMode;
+@property SYMETADATA_PROPERTY_COPY NSString              *flashSetting;
+@property SYMETADATA_PROPERTY_COPY NSString              *isoSelection;
+@property SYMETADATA_PROPERTY_COPY NSObject              *flashExposureComp;
+@property SYMETADATA_PROPERTY_COPY NSString              *imageAdjustment;
+@property SYMETADATA_PROPERTY_COPY NSObject              *lensAdapter;
+@property SYMETADATA_PROPERTY_COPY NSNumber              *lensType;
+@property SYMETADATA_PROPERTY_COPY NSObject              *lensInfo;
+@property SYMETADATA_PROPERTY_COPY NSNumber              *focusDistance;
+@property SYMETADATA_PROPERTY_COPY NSNumber              *digitalZoom;
+@property SYMETADATA_PROPERTY_COPY NSNumber              *shootingMode;
+@property SYMETADATA_PROPERTY_COPY NSString              *cameraSerialNumber;
+@property SYMETADATA_PROPERTY_COPY NSNumber              *shutterCount;
+
+@end

--- a/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadataMakerNikon.m
+++ b/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadataMakerNikon.m
@@ -1,0 +1,37 @@
+//
+//  SYMetadataMakerNikon.m
+//  SYPictureMetadataExample
+//
+//  Created by Stan Chevallier on 12/16/12.
+//  Copyright (c) 2012 Syan. All rights reserved.
+//
+
+#import "SYMetadataMakerNikon.h"
+#import <ImageIO/ImageIO.h>
+
+@implementation SYMetadataMakerNikon
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey
+{
+    return @{SYStringSel(isoSetting):           (NSString *)kCGImagePropertyMakerNikonISOSetting,
+             SYStringSel(colorMode):            (NSString *)kCGImagePropertyMakerNikonColorMode,
+             SYStringSel(quality):              (NSString *)kCGImagePropertyMakerNikonQuality,
+             SYStringSel(whiteBalanceMode):     (NSString *)kCGImagePropertyMakerNikonWhiteBalanceMode,
+             SYStringSel(sharpenMode):          (NSString *)kCGImagePropertyMakerNikonSharpenMode,
+             SYStringSel(focusMode):            (NSString *)kCGImagePropertyMakerNikonFocusMode,
+             SYStringSel(flashSetting):         (NSString *)kCGImagePropertyMakerNikonFlashSetting,
+             SYStringSel(isoSelection):         (NSString *)kCGImagePropertyMakerNikonISOSelection,
+             SYStringSel(flashExposureComp):    (NSString *)kCGImagePropertyMakerNikonFlashExposureComp,
+             SYStringSel(imageAdjustment):      (NSString *)kCGImagePropertyMakerNikonImageAdjustment,
+             SYStringSel(lensAdapter):          (NSString *)kCGImagePropertyMakerNikonLensAdapter,
+             SYStringSel(lensType):             (NSString *)kCGImagePropertyMakerNikonLensType,
+             SYStringSel(lensInfo):             (NSString *)kCGImagePropertyMakerNikonLensInfo,
+             SYStringSel(focusDistance):        (NSString *)kCGImagePropertyMakerNikonFocusDistance,
+             SYStringSel(digitalZoom):          (NSString *)kCGImagePropertyMakerNikonDigitalZoom,
+             SYStringSel(shootingMode):         (NSString *)kCGImagePropertyMakerNikonShootingMode,
+             SYStringSel(cameraSerialNumber):   (NSString *)kCGImagePropertyMakerNikonCameraSerialNumber,
+             SYStringSel(shutterCount):         (NSString *)kCGImagePropertyMakerNikonShutterCount,
+             };
+}
+
+@end

--- a/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadataMakerOlympus.h
+++ b/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadataMakerOlympus.h
@@ -1,0 +1,13 @@
+//
+//  SYMetadataMakerOlympus.h
+//  SYPictureMetadataExample
+//
+//  Created by Stan Chevallier on 12/16/12.
+//  Copyright (c) 2012 Syan. All rights reserved.
+//
+
+#import "SYMetadataBase.h"
+
+@interface SYMetadataMakerOlympus : SYMetadataBase
+
+@end

--- a/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadataMakerOlympus.m
+++ b/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadataMakerOlympus.m
@@ -1,0 +1,13 @@
+//
+//  SYMetadataMakerOlympus.m
+//  SYPictureMetadataExample
+//
+//  Created by Stan Chevallier on 12/16/12.
+//  Copyright (c) 2012 Syan. All rights reserved.
+//
+
+#import "SYMetadataMakerOlympus.h"
+
+@implementation SYMetadataMakerOlympus
+
+@end

--- a/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadataMakerPentax.h
+++ b/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadataMakerPentax.h
@@ -1,0 +1,13 @@
+//
+//  SYMetadataMakerPentax.h
+//  SYPictureMetadataExample
+//
+//  Created by Stan Chevallier on 12/16/12.
+//  Copyright (c) 2012 Syan. All rights reserved.
+//
+
+#import "SYMetadataBase.h"
+
+@interface SYMetadataMakerPentax : SYMetadataBase
+
+@end

--- a/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadataMakerPentax.m
+++ b/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadataMakerPentax.m
@@ -1,0 +1,13 @@
+//
+//  SYMetadataMakerPentax.m
+//  SYPictureMetadataExample
+//
+//  Created by Stan Chevallier on 12/16/12.
+//  Copyright (c) 2012 Syan. All rights reserved.
+//
+
+#import "SYMetadataMakerPentax.h"
+
+@implementation SYMetadataMakerPentax
+
+@end

--- a/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadataPNG.h
+++ b/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadataPNG.h
@@ -1,0 +1,51 @@
+//
+//  SYMetadataPNG.h
+//  SYPictureMetadataExample
+//
+//  Created by Stan Chevallier on 12/16/12.
+//  Copyright (c) 2012 Syan. All rights reserved.
+//
+
+#import "SYMetadataBase.h"
+#import <ImageIO/ImageIO.h>
+
+typedef enum : NSUInteger {
+    SYMetadataPNGsRGBIntent_Perceptual              = 0,
+    SYMetadataPNGsRGBIntent_RelativeColorimetric    = 1,
+    SYMetadataPNGsRGBIntent_Saturation              = 2,
+    SYMetadataPNGsRGBIntent_AbsoluteColorimetric    = 3,
+} SYMetadataPNGsRGBIntent;
+
+
+typedef enum : NSUInteger {
+    SYMetadataPNGCompressionFilter_NoFilters    = IMAGEIO_PNG_NO_FILTERS,
+    SYMetadataPNGCompressionFilter_None         = IMAGEIO_PNG_FILTER_NONE,
+    SYMetadataPNGCompressionFilter_Sub          = IMAGEIO_PNG_FILTER_SUB,
+    SYMetadataPNGCompressionFilter_Up           = IMAGEIO_PNG_FILTER_UP,
+    SYMetadataPNGCompressionFilter_Avg          = IMAGEIO_PNG_FILTER_AVG,
+    SYMetadataPNGCompressionFilter_Paeth        = IMAGEIO_PNG_FILTER_PAETH,
+    SYMetadataPNGCompressionFilter_All          = IMAGEIO_PNG_ALL_FILTERS,
+} SYMetadataPNGCompressionFilter;
+
+
+@interface SYMetadataPNG : SYMetadataBase
+
+@property SYMETADATA_PROPERTY_COPY NSNumber              *gamma;
+@property SYMETADATA_PROPERTY_COPY NSNumber              *interlaceType;
+@property SYMETADATA_PROPERTY_COPY NSNumber              *xPixelsPerMeter;
+@property SYMETADATA_PROPERTY_COPY NSNumber              *yPixelsPerMeter;
+@property SYMETADATA_PROPERTY_COPY NSNumber              *sRGBIntent;
+@property SYMETADATA_PROPERTY_COPY NSArray <NSNumber *>  *chromaticities;
+@property SYMETADATA_PROPERTY_COPY NSString              *author;
+@property SYMETADATA_PROPERTY_COPY NSString              *copyright;
+@property SYMETADATA_PROPERTY_COPY NSString              *creationTime;
+@property SYMETADATA_PROPERTY_COPY NSString              *descr;
+@property SYMETADATA_PROPERTY_COPY NSString              *modificationTime;
+@property SYMETADATA_PROPERTY_COPY NSString              *software;
+@property SYMETADATA_PROPERTY_COPY NSString              *title;
+@property SYMETADATA_PROPERTY_COPY NSNumber              *loopCount;
+@property SYMETADATA_PROPERTY_COPY NSNumber              *delayTime;
+@property SYMETADATA_PROPERTY_COPY NSNumber              *unclampedDelayTime;
+@property SYMETADATA_PROPERTY_COPY NSNumber              *compressionFilter;
+
+@end

--- a/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadataPNG.m
+++ b/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadataPNG.m
@@ -1,0 +1,36 @@
+//
+//  SYMetadataPNG.m
+//  SYPictureMetadataExample
+//
+//  Created by Stan Chevallier on 12/16/12.
+//  Copyright (c) 2012 Syan. All rights reserved.
+//
+
+#import "SYMetadataPNG.h"
+#import <ImageIO/ImageIO.h>
+
+@implementation SYMetadataPNG
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey
+{
+    return @{SYStringSel(gamma):                (NSString *)kCGImagePropertyPNGGamma,
+             SYStringSel(interlaceType):        (NSString *)kCGImagePropertyPNGInterlaceType,
+             SYStringSel(xPixelsPerMeter):      (NSString *)kCGImagePropertyPNGXPixelsPerMeter,
+             SYStringSel(yPixelsPerMeter):      (NSString *)kCGImagePropertyPNGYPixelsPerMeter,
+             SYStringSel(sRGBIntent):           (NSString *)kCGImagePropertyPNGsRGBIntent,
+             SYStringSel(chromaticities):       (NSString *)kCGImagePropertyPNGChromaticities,
+             SYStringSel(author):               (NSString *)kCGImagePropertyPNGAuthor,
+             SYStringSel(copyright):            (NSString *)kCGImagePropertyPNGCopyright,
+             SYStringSel(creationTime):         (NSString *)kCGImagePropertyPNGCreationTime,
+             SYStringSel(descr):                (NSString *)kCGImagePropertyPNGDescription,
+             SYStringSel(modificationTime):     (NSString *)kCGImagePropertyPNGModificationTime,
+             SYStringSel(software):             (NSString *)kCGImagePropertyPNGSoftware,
+             SYStringSel(title):                (NSString *)kCGImagePropertyPNGTitle,
+             SYStringSel(loopCount):            (NSString *)kCGImagePropertyAPNGLoopCount,
+             SYStringSel(delayTime):            (NSString *)kCGImagePropertyAPNGDelayTime,
+             SYStringSel(unclampedDelayTime):   (NSString *)kCGImagePropertyAPNGUnclampedDelayTime,
+             SYStringSel(compressionFilter):    (NSString *)kCGImagePropertyPNGCompressionFilter,
+             };
+}
+
+@end

--- a/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadataRaw.h
+++ b/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadataRaw.h
@@ -1,0 +1,13 @@
+//
+//  SYMetadataRaw.h
+//  SYPictureMetadataExample
+//
+//  Created by Stan Chevallier on 12/16/12.
+//  Copyright (c) 2012 Syan. All rights reserved.
+//
+
+#import "SYMetadataBase.h"
+
+@interface SYMetadataRaw : SYMetadataBase
+
+@end

--- a/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadataRaw.m
+++ b/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadataRaw.m
@@ -1,0 +1,13 @@
+//
+//  SYMetadataRaw.m
+//  SYPictureMetadataExample
+//
+//  Created by Stan Chevallier on 12/16/12.
+//  Copyright (c) 2012 Syan. All rights reserved.
+//
+
+#import "SYMetadataRaw.h"
+
+@implementation SYMetadataRaw
+
+@end

--- a/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadataTIFF.h
+++ b/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadataTIFF.h
@@ -1,0 +1,66 @@
+//
+//  SYMetadataTIFF.h
+//  SYPictureMetadataExample
+//
+//  Created by Stan Chevallier on 12/13/12.
+//  Copyright (c) 2012 Syan. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "SYMetadataBase.h"
+
+typedef enum {
+    SYPictureTiffOrientation_Unknown        = 0,
+    SYPictureTiffOrientation_TopLeft        = 1,
+    SYPictureTiffOrientation_TopRight       = 2,
+    SYPictureTiffOrientation_BottomRight    = 3,
+    SYPictureTiffOrientation_BottomLeft     = 4,
+    SYPictureTiffOrientation_LeftTop        = 5,
+    SYPictureTiffOrientation_RightTop       = 6,
+    SYPictureTiffOrientation_RightBottom    = 7,
+    SYPictureTiffOrientation_LeftBottom     = 8,
+} SYPictureTiffOrientation;
+
+
+typedef enum {
+    SYPictureTiffPhotometricInterpretation_MINISWHITE   = 0,
+    SYPictureTiffPhotometricInterpretation_MINISBLACK   = 1,
+    SYPictureTiffPhotometricInterpretation_RGB          = 2,
+    SYPictureTiffPhotometricInterpretation_PALETTE      = 3,
+    SYPictureTiffPhotometricInterpretation_MASK         = 4,
+    SYPictureTiffPhotometricInterpretation_SEPARATED    = 5,
+    SYPictureTiffPhotometricInterpretation_YCBCR        = 6,
+    SYPictureTiffPhotometricInterpretation_CIELAB       = 8,
+    SYPictureTiffPhotometricInterpretation_ICCLAB       = 9,
+    SYPictureTiffPhotometricInterpretation_ITULAB       = 10,
+    SYPictureTiffPhotometricInterpretation_LOGL         = 32844,
+    SYPictureTiffPhotometricInterpretation_LOGLUV       = 32845,
+} SYPictureTiffPhotometricInterpretation;
+
+
+
+@interface SYMetadataTIFF : SYMetadataBase
+
+@property SYMETADATA_PROPERTY_COPY NSNumber    *compression;
+@property SYMETADATA_PROPERTY_COPY NSNumber    *photometricInterpretation;
+@property SYMETADATA_PROPERTY_COPY NSString    *documentName;
+@property SYMETADATA_PROPERTY_COPY NSString    *imageDescription;
+@property SYMETADATA_PROPERTY_COPY NSString    *make;
+@property SYMETADATA_PROPERTY_COPY NSString    *model;
+@property SYMETADATA_PROPERTY_COPY NSNumber    *orientation;
+@property SYMETADATA_PROPERTY_COPY NSNumber    *xResolution;
+@property SYMETADATA_PROPERTY_COPY NSNumber    *yResolution;
+@property SYMETADATA_PROPERTY_COPY NSNumber    *resolutionUnit;
+@property SYMETADATA_PROPERTY_COPY NSString    *software;
+@property SYMETADATA_PROPERTY_COPY NSArray     *transferFunction;
+@property SYMETADATA_PROPERTY_COPY NSString    *dateTime;
+@property SYMETADATA_PROPERTY_COPY NSString    *artist;
+@property SYMETADATA_PROPERTY_COPY NSString    *hostComputer;
+@property SYMETADATA_PROPERTY_COPY NSString    *copyright;
+@property SYMETADATA_PROPERTY_COPY NSArray     *whitePoint;
+@property SYMETADATA_PROPERTY_COPY NSArray     *primaryChromaticities;
+@property SYMETADATA_PROPERTY_COPY NSNumber    *tileWidth;
+@property SYMETADATA_PROPERTY_COPY NSNumber    *tileLength;
+
+@end
+

--- a/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadataTIFF.m
+++ b/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/SYMetadataTIFF.m
@@ -1,0 +1,48 @@
+//
+//  SYMetadataTIFF.m
+//  SYPictureMetadataExample
+//
+//  Created by Stan Chevallier on 12/13/12.
+//  Copyright (c) 2012 Syan. All rights reserved.
+//
+
+#import "SYMetadataTIFF.h"
+#import <ImageIO/ImageIO.h>
+
+@implementation SYMetadataTIFF
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey
+{
+    return @{SYStringSel(compression):              (NSString *)kCGImagePropertyTIFFCompression,
+             SYStringSel(photometricInterpretation):(NSString *)kCGImagePropertyTIFFPhotometricInterpretation,
+             SYStringSel(documentName):             (NSString *)kCGImagePropertyTIFFDocumentName,
+             SYStringSel(imageDescription):         (NSString *)kCGImagePropertyTIFFImageDescription,
+             SYStringSel(make):                     (NSString *)kCGImagePropertyTIFFMake,
+             SYStringSel(model):                    (NSString *)kCGImagePropertyTIFFModel,
+             SYStringSel(orientation):              (NSString *)kCGImagePropertyTIFFOrientation,
+             SYStringSel(xResolution):              (NSString *)kCGImagePropertyTIFFXResolution,
+             SYStringSel(yResolution):              (NSString *)kCGImagePropertyTIFFYResolution,
+             SYStringSel(resolutionUnit):           (NSString *)kCGImagePropertyTIFFResolutionUnit,
+             SYStringSel(software):                 (NSString *)kCGImagePropertyTIFFSoftware,
+             SYStringSel(transferFunction):         (NSString *)kCGImagePropertyTIFFTransferFunction,
+             SYStringSel(dateTime):                 (NSString *)kCGImagePropertyTIFFDateTime,
+             SYStringSel(artist):                   (NSString *)kCGImagePropertyTIFFArtist,
+             SYStringSel(hostComputer):             (NSString *)kCGImagePropertyTIFFHostComputer,
+             SYStringSel(copyright):                (NSString *)kCGImagePropertyTIFFCopyright,
+             SYStringSel(whitePoint):               (NSString *)kCGImagePropertyTIFFWhitePoint,
+             SYStringSel(primaryChromaticities):    (NSString *)kCGImagePropertyTIFFPrimaryChromaticities,
+             
+             SYStringSel(tileWidth):                (NSString *)kCGImagePropertyTIFFTileWidth,
+             SYStringSel(tileLength):               (NSString *)kCGImagePropertyTIFFTileLength,
+             };
+}
+
++ (NSValueTransformer *)JSONTransformerForKey:(NSString *)key
+{
+    if ([key isEqualToString:SYStringSel(photometricInterpretation)])
+        return [MTLValueTransformer sy_nonZeroIntegerValueTransformer];
+    
+    return [super JSONTransformerForKey:key];
+}
+
+@end

--- a/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/UIImage+scale.h
+++ b/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/UIImage+scale.h
@@ -1,0 +1,12 @@
+//
+// Created by cjl on 2018/9/8.
+//
+
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
+@interface UIImage (scale)
+
+- (UIImage *)scaleWithMinWidth:(CGFloat)minWidth minHeight:(CGFloat)minHeight;
+- (UIImage *)rotate:(CGFloat) rotate;
+@end

--- a/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/UIImage+scale.m
+++ b/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/UIImage+scale.m
@@ -1,0 +1,74 @@
+//
+// Created by cjl on 2018/9/8.
+//
+
+#import "UIImage+scale.h"
+#import "ImageCompressPlugin.h"
+
+@implementation UIImage (scale)
+-(UIImage *)scaleWithMinWidth: (CGFloat)minWidth minHeight:(CGFloat)minHeight {
+    float actualHeight = self.size.height;
+    float actualWidth = self.size.width;
+    float imgRatio = actualWidth/actualHeight;
+    float maxRatio = minWidth/minHeight;
+    float scaleRatio = 1;
+    
+    if(imgRatio < maxRatio) {
+        scaleRatio = minWidth / actualWidth;
+    } else {
+        scaleRatio = minHeight / actualHeight;
+    }
+    scaleRatio = fminf(1, scaleRatio);
+
+    actualWidth = floor(scaleRatio * actualWidth);
+    actualHeight = floor(scaleRatio * actualHeight);
+    
+    CGRect rect = CGRectMake(0.0, 0.0, actualWidth, actualHeight);
+    UIGraphicsBeginImageContext(rect.size);
+    [self drawInRect:rect];
+    UIImage *newImage = UIGraphicsGetImageFromCurrentImageContext();
+    UIGraphicsEndImageContext();
+    
+    if([ImageCompressPlugin showLog]){
+        NSLog(@"scale = %.2f", scaleRatio);
+        NSLog(@"dst width = %.2f", rect.size.width);
+        NSLog(@"dst height = %.2f", rect.size.height);
+    }
+    
+    return newImage;
+}
+
+- (UIImage *)rotate:(CGFloat) rotate{
+    return [self imageRotatedByDegrees:self deg:rotate];
+}
+
+- (UIImage *)imageRotatedByDegrees:(UIImage*)oldImage deg:(CGFloat)degrees{
+    if([ImageCompressPlugin showLog]) {
+        NSLog(@"will rotate %f",degrees);
+    }
+    
+    // calculate the size of the rotated view's containing box for our drawing space
+    UIView *rotatedViewBox = [[UIView alloc] initWithFrame:CGRectMake(0,0,oldImage.size.width, oldImage.size.height)];
+    CGAffineTransform t = CGAffineTransformMakeRotation(degrees * M_PI / 180);
+    rotatedViewBox.transform = t;
+    CGSize rotatedSize = rotatedViewBox.frame.size;
+    // Create the bitmap context
+    UIGraphicsBeginImageContext(rotatedSize);
+    CGContextRef bitmap = UIGraphicsGetCurrentContext();
+    
+    // Move the origin to the middle of the image so we will rotate and scale around the center.
+    CGContextTranslateCTM(bitmap, rotatedSize.width/2, rotatedSize.height/2);
+    
+    //   // Rotate the image context
+    CGContextRotateCTM(bitmap, (degrees * M_PI / 180));
+    
+    // Now, draw the rotated/scaled image into the context
+    CGContextScaleCTM(bitmap, 1.0, -1.0);
+    CGContextDrawImage(bitmap, CGRectMake(-oldImage.size.width / 2, -oldImage.size.height / 2, oldImage.size.width, oldImage.size.height), [oldImage CGImage]);
+    
+    UIImage *newImage = UIGraphicsGetImageFromCurrentImageContext();
+    UIGraphicsEndImageContext();
+    return newImage;
+}
+
+@end


### PR DESCRIPTION
## Summary

- Add `Package.swift` and SPM-compatible source layout in `packages/flutter_image_compress_common/ios/flutter_image_compress_common/`
- Existing CocoaPods structure in `ios/Classes/` is preserved for backward compatibility
- SPM dependencies: [Mantle](https://github.com/Mantle/Mantle), [SDWebImage](https://github.com/SDWebImage/SDWebImage), [SDWebImageWebPCoder](https://github.com/SDWebImage/SDWebImageWebPCoder)
- Converts framework-style imports (`#import <Mantle/Mantle.h>`) to `@import Mantle;` for SPM module compatibility
- Adds explicit `#import <UIKit/UIKit.h>` where needed (SPM doesn't provide prefix headers)

## Context

Flutter now supports Swift Package Manager as a native dependency resolution mechanism. Plugins that provide a `Package.swift` in their `ios/<plugin_name>/` directory are automatically resolved via SPM, eliminating the need for CocoaPods fallback.

Without SPM support, Flutter falls back to CocoaPods for the entire project when even a single plugin lacks a `Package.swift`, which blocks projects from migrating to a pure SPM build.

## Test plan

- [x] `flutter build ios` succeeds with SPM enabled (`flutter config --enable-swift-package-manager`)
- [x] Zero CocoaPods fallback warnings in build output
- [x] Image compression and WebP encoding work correctly at runtime
- [x] `flutter build ios --release` produces a valid IPA (54.2MB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)