### PR TITLE
fix: Remove AssetsLibrary usage for iOS 26 compatibility

### DIFF
--- a/packages/flutter_image_compress_common/ios/Classes/SYPictureMetadata/SYMetadata.h
+++ b/packages/flutter_image_compress_common/ios/Classes/SYPictureMetadata/SYMetadata.h
@@ -29,8 +29,6 @@
 // http://www.sno.phy.queensu.ca/~phil/exiftool/TagNames/index.html
 // http://www.exiv2.org/tags.html
 
-@class ALAsset;
-
 @interface SYMetadata : SYMetadataBase
 
 @property SYMETADATA_PROPERTY_COPY NSDictionary *originalDictionary;
@@ -72,12 +70,8 @@
 @property (nonatomic, copy, readonly)   NSString  *profileName;
 
 + (instancetype)metadataWithDictionary:(NSDictionary *)dictionary;
-+ (instancetype)metadataWithAsset:(ALAsset *)asset __TVOS_PROHIBITED;
-+ (instancetype)metadataWithAssetURL:(NSURL *)assetURL __TVOS_PROHIBITED;
 + (instancetype)metadataWithFileURL:(NSURL *)fileURL;
 + (instancetype)metadataWithImageData:(NSData *)imageData;
-
-+ (NSDictionary *)dictionaryWithAssetURL:(NSURL *)assetURL __TVOS_PROHIBITED;
 
 + (NSData *)dataWithImageData:(NSData *)imageData andMetadata:(SYMetadata *)metadata;
 

--- a/packages/flutter_image_compress_common/ios/Classes/SYPictureMetadata/SYMetadata.m
+++ b/packages/flutter_image_compress_common/ios/Classes/SYPictureMetadata/SYMetadata.m
@@ -10,10 +10,6 @@
 #import "SYMetadata.h"
 #import "NSDictionary+SY.h"
 
-#if !TARGET_OS_TV
-#import <AssetsLibrary/AssetsLibrary.h>
-#endif
-
 #define SYKeyForMetadata(name)          NSStringFromSelector(@selector(metadata##name))
 #define SYDictionaryForMetadata(name)   SYPaste(SYPaste(kCGImageProperty,name),Dictionary)
 #define SYClassForMetadata(name)        SYPaste(SYMetadata,name)
@@ -44,22 +40,6 @@
         NSLog(@"--> Error creating %@ object: %@", NSStringFromClass(self.class), error);
     
     return instance;
-}
-
-+ (instancetype)metadataWithAsset:(ALAsset *)asset
-{
-#if !TARGET_OS_TV
-    ALAssetRepresentation *representation = [asset defaultRepresentation];
-    return [self metadataWithDictionary:[representation metadata]];
-#else
-    return nil;
-#endif
-}
-
-+ (instancetype)metadataWithAssetURL:(NSURL *)assetURL
-{
-    NSDictionary *dictionary = [self dictionaryWithAssetURL:assetURL];
-    return [self metadataWithDictionary:dictionary];
 }
 
 + (instancetype)metadataWithFileURL:(NSURL *)fileURL
@@ -142,33 +122,6 @@
     CFRelease(source);
     
     return (success ? data : nil);
-}
-
-#pragma mark - Getting metadata
-
-+ (NSDictionary *)dictionaryWithAssetURL:(NSURL *)assetURL
-{
-#if !TARGET_OS_TV
-    __block ALAsset *assetAtUrl = nil;
-    ALAssetsLibrary* library = [[ALAssetsLibrary alloc] init];
-    
-    dispatch_semaphore_t sema = dispatch_semaphore_create(0);
-    [library assetForURL:assetURL resultBlock:^(ALAsset *asset) {
-        assetAtUrl = asset;
-        dispatch_semaphore_signal(sema);
-    } failureBlock:^(NSError *error) {
-        dispatch_semaphore_signal(sema);
-    }];
-    dispatch_semaphore_wait(sema, DISPATCH_TIME_FOREVER);
-    
-    if (!assetAtUrl)
-        return nil;
-    
-    ALAssetRepresentation *representation = [assetAtUrl defaultRepresentation];
-    return [representation metadata];
-#else
-    return nil;
-#endif
 }
 
 #pragma mark - Mapping


### PR DESCRIPTION
## Summary
- Remove the AssetsLibrary framework import and the three ALAsset-based methods on `SYMetadata` (`metadataWithAsset:`, `metadataWithAssetURL:`, `dictionaryWithAssetURL:`) — AssetsLibrary is removed from the iOS 26 SDK.
- These methods have zero callers in this repository (verified via full-tree grep). The plugin's own metadata flow uses only `metadataWithFileURL:` / `metadataWithImageData:` / `dataWithImageData:andMetadata:`, all backed by `CGImageSource` and unaffected.

## Relationship to #343
#343 also targets iOS 26 but migrates the ALAsset methods to PHAsset, adding threading/iCloud/availability infrastructure for API that is not reachable from the plugin. This PR takes the minimal path — delete the dead code — since restoring PHAsset-equivalent functionality can happen in a follow-up if any external consumer ever needs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)