### PR TITLE
fix(ci): Restore CI green on main

### DIFF
--- a/packages/flutter_image_compress/example/android/app/build.gradle
+++ b/packages/flutter_image_compress/example/android/app/build.gradle
@@ -37,7 +37,7 @@ android {
 
     defaultConfig {
         applicationId "com.fluttercandies.flutterimagecompressexample"
-        minSdkVersion 21
+        minSdkVersion flutter.minSdkVersion
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/packages/flutter_image_compress/example/android/gradle.properties
+++ b/packages/flutter_image_compress/example/android/gradle.properties
@@ -1,6 +1,6 @@
 android.enableJetifier=true
 android.useAndroidX=true
-org.gradle.jvmargs=-Xmx1536M
+org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
 android.enableR8=true
 
 android.debug.obsoleteApi=true

--- a/packages/flutter_image_compress/example/android/gradle.properties
+++ b/packages/flutter_image_compress/example/android/gradle.properties
@@ -4,3 +4,7 @@ org.gradle.jvmargs=-Xmx1536M
 android.enableR8=true
 
 android.debug.obsoleteApi=true
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=false
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=false

--- a/packages/flutter_image_compress/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/flutter_image_compress/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip

--- a/packages/flutter_image_compress/example/android/settings.gradle
+++ b/packages/flutter_image_compress/example/android/settings.gradle
@@ -23,7 +23,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.2.2" apply false
+    id "com.android.application" version "8.6.0" apply false
     id "org.jetbrains.kotlin.android" version "1.9.20" apply false
 }
 

--- a/packages/flutter_image_compress/example/lib/main/main_io.dart
+++ b/packages/flutter_image_compress/example/lib/main/main_io.dart
@@ -250,9 +250,9 @@ class _MyAppState extends State<MyApp> {
   }
 
   /// The example for compressing heic format.
-  /// 
+  ///
   /// Convert jpeg to heic format, and then convert heic to jpg format.
-  /// 
+  ///
   /// Show the file path and size in the console.
   void _compressHeicExample() async {
     print('start compress');


### PR DESCRIPTION
## Summary
Two independent CI blockers on \`main\`:

- **format gate** — \`example/lib/main/main_io.dart\` had trailing whitespace on two dartdoc lines, tripping \`melos exec -- dart format . --set-exit-if-changed\`.
- **Android build gate** — the Flutter Gradle plugin now uses the \`filePermissions\` API (Gradle 8.3+) and enforces AGP >= 8.6.0. The example was pinned to Gradle 8.2.1 / AGP 8.2.2 and failed with \`Unresolved reference: filePermissions\` followed by an AGP version guard error.

Fix:
- Reformat the two lines.
- Bump the Android example: Gradle wrapper 8.2.1 → 8.7, AGP 8.2.2 → 8.6.0. Kotlin stays at 1.9.20.
- Keep the Flutter migrator's auto-inserted \`android.builtInKotlin=false\` and \`android.newDsl=false\` opt-outs, plus \`minSdkVersion flutter.minSdkVersion\` — these are what \`flutter build apk\` writes into the checkout on a modern toolchain, so committing them makes the state stable across upgrades.

Verified locally on Flutter 3.44.1 stable: all four CI jobs green — \`analyze\` (incl. format), \`try_build_ios\`, \`try_build_apk\`, \`try_build_web\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)