### PR TITLE
fix(iOS): don't crash on WebP + keepExif when ImageIO can't rewrite metadata

### DIFF
--- a/packages/flutter_image_compress/example/integration_test/compress_test.dart
+++ b/packages/flutter_image_compress/example/integration_test/compress_test.dart
@@ -461,6 +461,32 @@ void main() {
                 'that keepExif=false does not emit '
                 '(src=$srcKeys kept=$keptKeys dropped=$droppedKeys)');
       });
+
+      testWidgets(
+        'WebP + keepExif=true: does not crash, emits a valid WebP',
+        (_) async {
+          // Regression for issue #217: iOS crashed on WebP + keepExif=true
+          // because SYMetadata's ImageIO-backed rewrite returns nil for
+          // containers ImageIO can't author (WebP), and the nil bytes were
+          // then handed to FlutterStandardTypedData typedDataWithBytes:.
+          final src = await loadAssetBytes('img/auto-angle.jpg');
+          final result = await FlutterImageCompress.compressWithList(
+            src,
+            minWidth: 500,
+            minHeight: 500,
+            quality: 80,
+            format: CompressFormat.webp,
+            keepExif: true,
+          );
+          expectValidCompressed(
+            bytes: result,
+            expected: DetectedFormat.webp,
+            description: 'WebP + keepExif',
+          );
+        },
+        // WebP is iOS/Android only in the common package.
+        skip: !Platform.isIOS,
+      );
     },
     // macOS's keepExif implementation flattens source properties into the
     // CGImageDestination options dictionary as top-level keys, which is

--- a/packages/flutter_image_compress_common/CHANGELOG.md
+++ b/packages/flutter_image_compress_common/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 1.1.0
 
+- **FIX**(iOS): Don't crash on WebP + `keepExif: true`. `SYMetadata`'s ImageIO-backed rewrite returns `nil` for containers it can't author (e.g. WebP); the handlers now preserve the original compressed bytes on that failure instead of forwarding `nil` to `FlutterStandardTypedData` ([#217](https://github.com/fluttercandies/flutter_image_compress/issues/217)).
 - **FEAT**(iOS): Add Swift Package Manager support (Package.swift alongside podspec).
 - **REFACTOR**(iOS): Reorganize Objective-C sources into `Sources/flutter_image_compress_common/` layout compatible with SPM. Public headers moved to `include/flutter_image_compress_common/`. Cocoapods integration continues to work.
 

--- a/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/CompressFileHandler.m
+++ b/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/CompressFileHandler.m
@@ -48,9 +48,20 @@
     if (keepExif) {
         SYMetadata *metadata = [SYMetadata metadataWithFileURL:[NSURL fileURLWithPath:path]];
         metadata.orientation = @0;
-        data = [SYMetadata dataWithImageData:data andMetadata:metadata];
+        // ImageIO can't write every container we can encode (notably WebP),
+        // so dataWithImageData:andMetadata: can return nil. Fall back to the
+        // original compressed bytes instead of overwriting them with nil —
+        // otherwise typedDataWithBytes: below crashes.
+        NSData *withMetadata = [SYMetadata dataWithImageData:data andMetadata:metadata];
+        if (withMetadata.length > 0) {
+            data = withMetadata;
+        }
     }
 
+    if (data == nil) {
+        result(nil);
+        return;
+    }
     result([FlutterStandardTypedData typedDataWithBytes:data]);
 }
 
@@ -90,7 +101,13 @@
     if (keepExif) {
         SYMetadata *metadata = [SYMetadata metadataWithFileURL:[NSURL fileURLWithPath:path]];
         metadata.orientation = @0;
-        data = [SYMetadata dataWithImageData:data andMetadata:metadata];
+        // See handleMethodCall: dataWithImageData:andMetadata: returns nil for
+        // containers ImageIO can't rewrite (e.g. WebP). Keep the original
+        // encoded bytes on failure so the caller still receives a valid file.
+        NSData *withMetadata = [SYMetadata dataWithImageData:data andMetadata:metadata];
+        if (withMetadata.length > 0) {
+            data = withMetadata;
+        }
     }
 
     if (data == nil) {

--- a/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/CompressListHandler.m
+++ b/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/CompressListHandler.m
@@ -34,7 +34,14 @@
     if (keepExif) {
         SYMetadata *metadata = [SYMetadata metadataWithImageData:data];
         metadata.orientation = @0;
-        compressedData = [SYMetadata dataWithImageData:compressedData andMetadata:metadata];
+        // ImageIO's CGImageDestination doesn't support writing every container
+        // we can encode (notably WebP), so dataWithImageData:andMetadata: can
+        // return nil. Preserve the original compressed bytes on failure —
+        // otherwise typedDataWithBytes: below would receive nil and crash.
+        NSData *withMetadata = [SYMetadata dataWithImageData:compressedData andMetadata:metadata];
+        if (withMetadata.length > 0) {
+            compressedData = withMetadata;
+        }
     }
 
     result([FlutterStandardTypedData typedDataWithBytes:compressedData]);


### PR DESCRIPTION
## Summary

Fixes #217 — on iOS, `compressWithList` / `compressWithFile` / `compressAndGetFile` with `format: CompressFormat.webp` **and** `keepExif: true` crashed the app.

Root cause: `SYMetadata.dataWithImageData:andMetadata:` is backed by ImageIO's `CGImageDestination`, which cannot author WebP containers. It returns `nil` in that case. The handlers were unconditionally overwriting the compressed bytes with that `nil`, then handing them to `[FlutterStandardTypedData typedDataWithBytes:]` — which asserts on `nil`.

Fix (matches the pattern established by #358):
- Preserve the original compressed bytes when the metadata rewrite returns `nil`. The output still won't carry EXIF (ImageIO fundamentally can't write it into WebP), but the compressed image is valid and returned to Dart instead of crashing.
- Nil-guard the byte-array path in `CompressFileHandler.handleMethodCall:` for defense in depth (the file-mode path already had this guard from #358).
- Regression integration test: WebP + `keepExif: true` must return a valid WebP without crashing.

Changelog entry (auto-generated by `melos version` from the Conventional Commit):

> **fix(iOS):** don't crash on WebP + keepExif when ImageIO can't rewrite metadata

## Supersedes #364

Closes #364. That PR:
- targeted the pre-SPM Objective-C paths under `ios/Classes/` (they moved in a77d6c4 / #368) so it no longer applies to `main`,
- serialized the whole `CGImageSourceCopyPropertiesAtIndex` result as JSON and shoved it into the WebP `EXIF` chunk — the EXIF chunk expects raw TIFF-formatted EXIF, so any downstream reader would fail to parse it,
- restructured method dispatch (moving `handleMethodCall:` demultiplexing into the handler) in ways unrelated to the crash.

The minimal fix here addresses the actual crash surface without introducing new native dependencies or malformed EXIF payloads.

## Test plan

- [x] `melos run analyze`
- [x] `melos run format`
- [ ] CI: `try_build_ios`, `try_build_ios_swift_package_manager`, `verify_ios_behavior` (the added integration test must pass on the iOS simulator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)