### PR TITLE
fix(iOS): compute rotated bbox off the main thread without UIKit (#353)

### DIFF
--- a/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/UIImage+scale.m
+++ b/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/UIImage+scale.m
@@ -65,10 +65,10 @@
     }
     
     // calculate the size of the rotated view's containing box for our drawing space
-    UIView *rotatedViewBox = [[UIView alloc] initWithFrame:CGRectMake(0,0,oldImage.size.width, oldImage.size.height)];
+    // compute rotated bbox without touching UIKit — this method runs off the main thread
     CGAffineTransform t = CGAffineTransformMakeRotation(degrees * M_PI / 180);
-    rotatedViewBox.transform = t;
-    CGSize rotatedSize = rotatedViewBox.frame.size;
+    CGRect rotatedRect = CGRectApplyAffineTransform(CGRectMake(0, 0, oldImage.size.width, oldImage.size.height), t);
+    CGSize rotatedSize = rotatedRect.size;
 
     UIImage *newImage;
     if (@available(iOS 10.0, *)) {


### PR DESCRIPTION
## Summary
- Fixes #353 — the compression thread was allocating a `UIView` inside `-imageRotatedByDegrees:deg:` just to derive the rotated bounding box via `.frame.size`. `-[UIView initWithFrame:]` is a UIKit API and can only be called on the main thread; Main Thread Checker flagged it on iOS 15+ and stricter iOS 17+ builds crash outright.
- Replaces the UIView trick with `CGRectApplyAffineTransform`, which is pure Core Graphics and thread-safe. `UIView.frame` under a non-identity `.transform` is defined as the smallest rect containing the transformed bounds — exactly what `CGRectApplyAffineTransform` computes on the same input.

## Test plan
- [x] Semantic equivalence verified for 0° / ±90° / 45° / 180° — same non-negative width/height output.
- [x] No other references to the removed `rotatedViewBox` in the file.
- [ ] `melos run verify_ios_behavior` on a booted simulator (existing rotate integration coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)