### PR TITLE
fix(macOS): stop crashing when CGImageDestinationCreate returns nil (#339, #314)

### DIFF
--- a/packages/flutter_image_compress_macos/macos/flutter_image_compress_macos/Sources/flutter_image_compress_macos/FlutterImageCompressMacosPlugin.swift
+++ b/packages/flutter_image_compress_macos/macos/flutter_image_compress_macos/Sources/flutter_image_compress_macos/FlutterImageCompressMacosPlugin.swift
@@ -264,7 +264,7 @@ class Compressor {
     return dict as CFDictionary
   }
 
-  func compress(destCreator: () -> CGImageDestination) {
+  func compress(destCreator: () -> CGImageDestination?) -> Bool {
     let minWidth = CGFloat(params["minWidth"] as! Int)
     let minHeight = CGFloat(params["minHeight"] as! Int)
     
@@ -307,16 +307,28 @@ class Compressor {
     let targetHeight = srcHeight * scaleRatio
 
     let targetSize = CGSize(width: targetWidth, height: targetHeight)
-    let dest = destCreator()
+    guard let dest = destCreator() else {
+      return false
+    }
     let angle = params["rotate"] as! Int
 
     handleImage(image: image.image, angle: angle, targetSize: targetSize, dest: dest)
+    return true
   }
 
   func compressToPath(_ result: @escaping (Any?) -> (), _ path: String) {
     let url = URL(fileURLWithPath: path)
-    compress {
-      CGImageDestinationCreateWithURL(url as CFURL, getOutputFormat(), 1, nil)!
+    let ok = compress { () -> CGImageDestination? in
+      guard let dest = CGImageDestinationCreateWithURL(url as CFURL, getOutputFormat(), 1, nil) else {
+        Logger.log(msg: "CGImageDestinationCreateWithURL returned nil for path \(path) — format may be unsupported or path unwritable")
+        return nil
+      }
+      return dest
+    }
+
+    if (!ok) {
+      result(nil)
+      return
     }
 
     Logger.logFile(path: path)
@@ -325,8 +337,17 @@ class Compressor {
 
   func compressToBytes(_ result: @escaping (Any?) -> ()) {
     let data = NSMutableData()
-    compress {
-      CGImageDestinationCreateWithData(data, getOutputFormat(), 1, nil)!
+    let ok = compress { () -> CGImageDestination? in
+      guard let dest = CGImageDestinationCreateWithData(data, getOutputFormat(), 1, nil) else {
+        Logger.log(msg: "CGImageDestinationCreateWithData returned nil — output format may be unsupported on this macOS version")
+        return nil
+      }
+      return dest
+    }
+
+    if (!ok) {
+      result(nil)
+      return
     }
 
     Logger.logData(data: data as Data)


### PR DESCRIPTION
## Summary
- Fixes #339 and #314 — `FlutterImageCompressMacosPlugin.swift:319` / `:329` force-unwrapped `CGImageDestinationCreateWithURL` / `CreateWithData`. Both return `nil` for unsupported output UTIs on the current macOS version, unwritable paths, or sandbox denials — turning any of those into a fatal `Unexpectedly found nil while unwrapping an Optional value`.
- `compress(destCreator:)` now accepts an optional-returning closure and returns `Bool`. `compressToPath` / `compressToBytes` `guard let` the destination, log a diagnostic via `Logger.log`, and reply `nil` to Dart on failure. This matches how other failure modes in the same file already surface — `compressAndGetFile` / `compressWithFile` return `null`; `compressWithList` throws `Compress failed`.

## Test plan
- [x] `result(...)` still called exactly once on every path (success + new failure).
- [x] Only in-file callers of `compress()` are the two updated sites.
- [x] Verifier confirmed `Logger.log(msg:)` signature and Dart-side null handling.
- [ ] `melos run verify_macos_behavior` locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)