### PR TITLE
fix(Android): don't kill the process when the input file is unreadable (#122)

### DIFF
--- a/packages/flutter_image_compress_common/android/src/main/kotlin/com/fluttercandies/flutter_image_compress/core/CompressFileHandler.kt
+++ b/packages/flutter_image_compress_common/android/src/main/kotlin/com/fluttercandies/flutter_image_compress/core/CompressFileHandler.kt
@@ -32,20 +32,20 @@ class CompressFileHandler(private val call: MethodCall, result: MethodChannel.Re
                 reply(null)
                 return@execute
             }
-            val exifRotate = if (autoCorrectionAngle) {
-                val bytes = File(filePath).readBytes()
-                Exif.getRotationDegrees(bytes)
-            } else {
-                0
-            }
-            if (exifRotate == 270 || exifRotate == 90) {
-                val tmp = minWidth
-                minWidth = minHeight
-                minHeight = tmp
-            }
-            val targetRotate = rotate + exifRotate
             val outputStream = ByteArrayOutputStream()
             try {
+                val exifRotate = if (autoCorrectionAngle) {
+                    val bytes = File(filePath).readBytes()
+                    Exif.getRotationDegrees(bytes)
+                } else {
+                    0
+                }
+                if (exifRotate == 270 || exifRotate == 90) {
+                    val tmp = minWidth
+                    minWidth = minHeight
+                    minHeight = tmp
+                }
+                val targetRotate = rotate + exifRotate
                 formatHandler.handleFile(
                     context,
                     filePath,
@@ -79,11 +79,6 @@ class CompressFileHandler(private val call: MethodCall, result: MethodChannel.Re
             val targetPath = args[4] as String
             val rotate = args[5] as Int
             val autoCorrectionAngle = args[6] as Boolean
-            val exifRotate = if (autoCorrectionAngle) {
-                Exif.getRotationDegrees(File(file))
-            } else {
-                0
-            }
             val format = args[7] as Int
             val keepExif = args[8] as Boolean
             val inSampleSize = args[9] as Int
@@ -94,14 +89,19 @@ class CompressFileHandler(private val call: MethodCall, result: MethodChannel.Re
                 reply(null)
                 return@execute
             }
-            if (exifRotate == 270 || exifRotate == 90) {
-                val tmp = minWidth
-                minWidth = minHeight
-                minHeight = tmp
-            }
-            val targetRotate = rotate + exifRotate
             var outputStream: OutputStream? = null
             try {
+                val exifRotate = if (autoCorrectionAngle) {
+                    Exif.getRotationDegrees(File(file))
+                } else {
+                    0
+                }
+                if (exifRotate == 270 || exifRotate == 90) {
+                    val tmp = minWidth
+                    minWidth = minHeight
+                    minHeight = tmp
+                }
+                val targetRotate = rotate + exifRotate
                 outputStream = File(targetPath).outputStream()
                 formatHandler.handleFile(
                     context,


### PR DESCRIPTION
## Summary
- Fixes #122 — a corrupted / permission-denied / missing input file made `File(path).readBytes()` (or `Exif.getRotationDegrees(File)`) throw an `IOException` / `FileNotFoundException` / `SecurityException` **outside** the existing `try { ... } catch (e: Exception)` in `CompressFileHandler.handle` / `handleGetFile`. Because the throw escaped the `threadPool.execute { ... }` lambda, Android's default uncaught-exception handler killed the whole app.
- Move the EXIF read + pre-compression setup inside the existing try in both handlers. Any `Exception` (including the ones above) is now logged via the existing `if (ImageCompressPlugin.showLog) e.printStackTrace()` gate and reported as `reply(null)`, matching the rest of the file.
- Reorders the arg reads for `format` / `keepExif` / `inSampleSize` / `numberOfRetries` up in `handleGetFile` so the `formatHandler` null-check stays outside the try (mirroring how `handle` already lays it out). Arg indices unchanged.

## Test plan
- [x] Verifier confirmed exception coverage — `readBytes` throws `IOException` (subclass of `Exception`), now caught.
- [x] `ResultHandler.reply` is idempotent via `isReply`; no double-call risk.
- [x] `outputStream?.close()` in `finally` still safe (var declared outside try).
- [ ] Repro locally: feed a random-bytes .jpg into `compressWithFile` and confirm null return instead of process death.

🤖 Generated with [Claude Code](https://claude.com/claude-code)