### PR TITLE
fix(Android): decode into ARGB_8888 instead of RGB_565 (#330 #280 #146 #248)

### DIFF
--- a/packages/flutter_image_compress_common/android/src/main/kotlin/com/fluttercandies/flutter_image_compress/handle/common/CommonHandler.kt
+++ b/packages/flutter_image_compress_common/android/src/main/kotlin/com/fluttercandies/flutter_image_compress/handle/common/CommonHandler.kt
@@ -60,7 +60,7 @@ class CommonHandler(override val type: Int) : FormatHandler {
     ): ByteArray {
         val options = BitmapFactory.Options()
         options.inJustDecodeBounds = false
-        options.inPreferredConfig = Bitmap.Config.RGB_565
+        options.inPreferredConfig = Bitmap.Config.ARGB_8888
         options.inSampleSize = inSampleSize
         if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.M) {
             @Suppress("DEPRECATION")
@@ -103,7 +103,7 @@ class CommonHandler(override val type: Int) : FormatHandler {
             if (numberOfRetries <= 0) return;
             val options = BitmapFactory.Options()
             options.inJustDecodeBounds = false
-            options.inPreferredConfig = Bitmap.Config.RGB_565
+            options.inPreferredConfig = Bitmap.Config.ARGB_8888
             options.inSampleSize = inSampleSize
             if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.M) {
                 @Suppress("DEPRECATION")

--- a/packages/flutter_image_compress_common/android/src/main/kotlin/com/fluttercandies/flutter_image_compress/handle/heif/HeifHandler.kt
+++ b/packages/flutter_image_compress_common/android/src/main/kotlin/com/fluttercandies/flutter_image_compress/handle/heif/HeifHandler.kt
@@ -65,7 +65,7 @@ class HeifHandler : FormatHandler {
     private fun makeOption(inSampleSize: Int): BitmapFactory.Options {
         val options = BitmapFactory.Options()
         options.inJustDecodeBounds = false
-        options.inPreferredConfig = Bitmap.Config.RGB_565
+        options.inPreferredConfig = Bitmap.Config.ARGB_8888
         options.inSampleSize = inSampleSize
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
             @Suppress("DEPRECATION")


### PR DESCRIPTION
## Summary
- Fixes #330 (reporter-supplied patch), #280, #146, #248.
- `BitmapFactory.Options.inPreferredConfig` was hard-coded to `Bitmap.Config.RGB_565` at three decode sites (2 in `CommonHandler.kt`, 1 in `HeifHandler.kt`). RGB_565 is a 16-bit-per-pixel format with 5/6/5 bits and no alpha, which is why users saw color banding at `quality=100`, occasional colored-line artifacts, and PNG alpha getting silently flattened.
- Flip all three sites to `Bitmap.Config.ARGB_8888` (32 bpp, full alpha).

## Test plan
- [x] Existing `transparent PNG retains alpha channel through compression` integration test in `example/integration_test/compress_test.dart` exercises the Android decode + PNG encode path — would catch a regression on the alpha side.
- [x] OOM retry loop (`CommonHandler.handleFile` inSampleSize halving) unaffected; memory doubles per pixel but the fallback path already handles that.
- [x] `Bitmap.compress(JPEG, …)` flattens alpha automatically, so JPEG outputs stay correct.
- [x] Zero remaining `RGB_565` references in `packages/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)