### PR TITLE
fix(iOS): reject non-image input files instead of returning a bogus XFile (#283)

### DIFF
--- a/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/CompressFileHandler.m
+++ b/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/CompressFileHandler.m
@@ -4,6 +4,7 @@
 
 #import "CompressFileHandler.h"
 #import "CompressHandler.h"
+#import "ImageCompressPlugin.h"
 #import "SYMetadata.h"
 @import SDWebImageWebPCoder;
 @import SDWebImage;
@@ -28,20 +29,35 @@
     
     NSURL *imageUrl = [NSURL fileURLWithPath:path];
     NSData *nsdata = [NSData dataWithContentsOfURL:imageUrl];
-    
+
+    if (nsdata == nil) {
+        if ([ImageCompressPlugin showLog]) {
+            NSLog(@"Input file could not be read (path=%@)", path);
+        }
+        result(nil);
+        return;
+    }
+
     NSString *imageType = [self mimeTypeByGuessingFromData:nsdata];
-    
+
     //  NSLog(@" nsdata length: %@", imageType);
-    
+
     SDImageWebPCoder *webPCoder = [SDImageWebPCoder sharedCoder];
     [[SDImageCodersManager sharedManager] addCoder:webPCoder];
-    
+
     if([imageType  isEqual: @"image/webp"]) {
     img = [[SDImageWebPCoder sharedCoder] decodedImageWithData:nsdata options:nil];
     } else {
         img = [UIImage imageWithData:nsdata];
     }
 
+    if (img == nil) {
+        if ([ImageCompressPlugin showLog]) {
+            NSLog(@"Input file is not a decodable image (mime=%@, path=%@)", imageType, path);
+        }
+        result(nil);
+        return;
+    }
 
     NSData *data = [CompressHandler compressWithUIImage:img minWidth:minWidth minHeight:minHeight quality:quality rotate:rotate format:formatType];
 
@@ -82,20 +98,36 @@
     
     NSURL *imageUrl = [NSURL fileURLWithPath:path];
     NSData *nsdata = [NSData dataWithContentsOfURL:imageUrl];
-    
+
+    if (nsdata == nil) {
+        if ([ImageCompressPlugin showLog]) {
+            NSLog(@"Input file could not be read (path=%@)", path);
+        }
+        result(nil);
+        return;
+    }
+
     NSString *imageType = [self mimeTypeByGuessingFromData:nsdata];
-    
+
     //  NSLog(@" nsdata length: %@", imageType);
-    
+
     SDImageWebPCoder *webPCoder = [SDImageWebPCoder sharedCoder];
     [[SDImageCodersManager sharedManager] addCoder:webPCoder];
-    
+
     if([imageType  isEqual: @"image/webp"]) {
     img = [[SDImageWebPCoder sharedCoder] decodedImageWithData:nsdata options:nil];
     } else {
         img = [UIImage imageWithData:nsdata];
     }
-    
+
+    if (img == nil) {
+        if ([ImageCompressPlugin showLog]) {
+            NSLog(@"Input file is not a decodable image (mime=%@, path=%@)", imageType, path);
+        }
+        result(nil);
+        return;
+    }
+
     NSData *data = [CompressHandler compressDataWithUIImage:img minWidth:minWidth minHeight:minHeight quality:quality rotate:rotate format:formatType];
 
     if (keepExif) {


### PR DESCRIPTION
## Summary
- Fixes #283 — feeding a live-photo video (or any file `[UIImage imageWithData:]` can't decode) into `compressWithFile` / `compressAndGetFile` used to return an "XFile" whose path either didn't exist or held garbage bytes; callers only found out at read time.
- Add two guards to both entry points of `CompressFileHandler.m`:
  1. If `[NSData dataWithContentsOfURL:]` returned nil (unreadable), reply `nil` early.
  2. If the decoded `UIImage` is nil (post-WebP branch or post-`imageWithData:`), reply `nil` early.
- HEIC is deliberately **not** filtered on mime — the `mimeTypeByGuessingFromData:` helper doesn't detect it, but `[UIImage imageWithData:]` handles HEIC natively on iOS 11+, so the `img == nil` guard is what actually separates real images from non-images (the earlier draft's `application/octet-stream` guard was dropped for exactly this reason).
- Both guards log via the existing `[ImageCompressPlugin showLog]` gate, matching the file's style.

## Test plan
- [x] Verified `result(...)` is still called exactly once on every path (nsdata nil, img nil, success, keepExif failure).
- [x] Verified HEIC bytes fall through mime detection → `[UIImage imageWithData:]` → decoded successfully, i.e. no HEIC regression.
- [x] Verified Dart side (`flutter_image_compress_common.dart`) translates a nil channel reply to a `null` `XFile?` for `compressAndGetFile`, so the fix reaches the user cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)