### PR TITLE
fix(Android): mkdirs the target path's parent before writing (#194 #181 #90)

### DIFF
--- a/packages/flutter_image_compress_common/android/src/main/kotlin/com/fluttercandies/flutter_image_compress/core/CompressFileHandler.kt
+++ b/packages/flutter_image_compress_common/android/src/main/kotlin/com/fluttercandies/flutter_image_compress/core/CompressFileHandler.kt
@@ -102,6 +102,7 @@ class CompressFileHandler(private val call: MethodCall, result: MethodChannel.Re
                     minHeight = tmp
                 }
                 val targetRotate = rotate + exifRotate
+                File(targetPath).parentFile?.mkdirs()
                 outputStream = File(targetPath).outputStream()
                 formatHandler.handleFile(
                     context,


### PR DESCRIPTION
## Summary
- Fixes #194, #181, #90 — `compressAndGetFile` returned `null` with no explanation whenever the caller passed a `targetPath` whose parent directory didn't exist. Repro: `${tempDir.path}/image_compress/foo.jpg`. Root cause: `File(targetPath).outputStream()` throws `FileNotFoundException`, gets caught by the surrounding `try / catch (e: Exception)`, and turns into `reply(null)`.
- Add `File(targetPath).parentFile?.mkdirs()` right before opening the output stream in `handleGetFile()`.
- `mkdirs()` is idempotent, no-op when the directory exists, safe on a null `parentFile`, and still inside the existing try — any `SecurityException` from a locked-down parent flows through the same `catch` as before, so the failure mode is preserved on genuinely-unwritable paths.

## Test plan
- [x] Verified placement is inside the existing try block, so no new exception path escapes the thread pool lambda.
- [x] Verified `handle()` (the `compressWithFile` byte-stream variant) is intentionally untouched — no filesystem parent involved.
- [x] Verified this doesn't regress any existing integration test — the current tests write to `dir.path` which always exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)