### PR TITLE
fix(Android): preserve full EXIF and stop leaking tmp .jpg in ExifKeeper (#159 #185)

### DIFF
--- a/packages/flutter_image_compress_common/android/src/main/kotlin/com/fluttercandies/flutter_image_compress/exif/ExifKeeper.java
+++ b/packages/flutter_image_compress_common/android/src/main/kotlin/com/fluttercandies/flutter_image_compress/exif/ExifKeeper.java
@@ -19,25 +19,126 @@ import java.util.UUID;
 import androidx.exifinterface.media.ExifInterface;
 
 public class ExifKeeper {
+    // Tags copied from the source image to the re-encoded output. We reference
+    // ExifInterface.TAG_* constants (compile-time strings) so the list stays in
+    // sync with the library. We intentionally skip:
+    //   - fields invalidated by re-encoding / resizing:
+    //       TAG_IMAGE_WIDTH, TAG_IMAGE_LENGTH, TAG_PIXEL_X_DIMENSION,
+    //       TAG_PIXEL_Y_DIMENSION
+    //   - JPEG structural fields the encoder rewrites:
+    //       TAG_BITS_PER_SAMPLE, TAG_COMPRESSION, TAG_SAMPLES_PER_PIXEL,
+    //       TAG_ROWS_PER_STRIP, TAG_STRIP_BYTE_COUNTS, TAG_STRIP_OFFSETS,
+    //       TAG_PHOTOMETRIC_INTERPRETATION, TAG_PLANAR_CONFIGURATION
+    //   - thumbnail pointers/data:
+    //       TAG_JPEG_INTERCHANGE_FORMAT, TAG_JPEG_INTERCHANGE_FORMAT_LENGTH,
+    //       and all TAG_THUMBNAIL_*
     private static final List<String> attributes = Arrays.asList(
-            "FNumber",
-            "ExposureTime",
-            "ISOSpeedRatings",
-            "GPSAltitude",
-            "GPSAltitudeRef",
-            "FocalLength",
-            "GPSDateStamp",
-            "WhiteBalance",
-            "GPSProcessingMethod",
-            "GPSTimeStamp",
-            "DateTime",
-            "Flash",
-            "GPSLatitude",
-            "GPSLatitudeRef",
-            "GPSLongitude",
-            "GPSLongitudeRef",
-            "Make",
-            "Model"
+            // Descriptive / authorship
+            ExifInterface.TAG_IMAGE_DESCRIPTION,
+            ExifInterface.TAG_MAKE,
+            ExifInterface.TAG_MODEL,
+            ExifInterface.TAG_SOFTWARE,
+            ExifInterface.TAG_ARTIST,
+            ExifInterface.TAG_COPYRIGHT,
+            ExifInterface.TAG_USER_COMMENT,
+
+            // Orientation and resolution
+            ExifInterface.TAG_ORIENTATION,
+            ExifInterface.TAG_X_RESOLUTION,
+            ExifInterface.TAG_Y_RESOLUTION,
+            ExifInterface.TAG_RESOLUTION_UNIT,
+            ExifInterface.TAG_Y_CB_CR_POSITIONING,
+
+            // Date/time
+            ExifInterface.TAG_DATETIME,
+            ExifInterface.TAG_DATETIME_ORIGINAL,
+            ExifInterface.TAG_DATETIME_DIGITIZED,
+            ExifInterface.TAG_SUBSEC_TIME,
+            ExifInterface.TAG_SUBSEC_TIME_ORIGINAL,
+            ExifInterface.TAG_SUBSEC_TIME_DIGITIZED,
+            ExifInterface.TAG_OFFSET_TIME,
+            ExifInterface.TAG_OFFSET_TIME_ORIGINAL,
+            ExifInterface.TAG_OFFSET_TIME_DIGITIZED,
+
+            // Exposure / capture parameters
+            ExifInterface.TAG_EXPOSURE_TIME,
+            ExifInterface.TAG_F_NUMBER,
+            ExifInterface.TAG_EXPOSURE_PROGRAM,
+            ExifInterface.TAG_ISO_SPEED_RATINGS,
+            ExifInterface.TAG_SHUTTER_SPEED_VALUE,
+            ExifInterface.TAG_APERTURE_VALUE,
+            ExifInterface.TAG_BRIGHTNESS_VALUE,
+            ExifInterface.TAG_EXPOSURE_BIAS_VALUE,
+            ExifInterface.TAG_MAX_APERTURE_VALUE,
+            ExifInterface.TAG_SUBJECT_DISTANCE,
+            ExifInterface.TAG_METERING_MODE,
+            ExifInterface.TAG_LIGHT_SOURCE,
+            ExifInterface.TAG_FLASH,
+            ExifInterface.TAG_FOCAL_LENGTH,
+            ExifInterface.TAG_FLASH_ENERGY,
+            ExifInterface.TAG_EXPOSURE_INDEX,
+            ExifInterface.TAG_SENSITIVITY_TYPE,
+            ExifInterface.TAG_EXPOSURE_MODE,
+            ExifInterface.TAG_WHITE_BALANCE,
+            ExifInterface.TAG_DIGITAL_ZOOM_RATIO,
+            ExifInterface.TAG_FOCAL_LENGTH_IN_35MM_FILM,
+            ExifInterface.TAG_SCENE_CAPTURE_TYPE,
+            ExifInterface.TAG_GAIN_CONTROL,
+            ExifInterface.TAG_CONTRAST,
+            ExifInterface.TAG_SATURATION,
+            ExifInterface.TAG_SHARPNESS,
+            ExifInterface.TAG_SUBJECT_DISTANCE_RANGE,
+
+            // EXIF metadata versions / color space
+            ExifInterface.TAG_EXIF_VERSION,
+            ExifInterface.TAG_FLASHPIX_VERSION,
+            ExifInterface.TAG_COLOR_SPACE,
+            ExifInterface.TAG_COMPONENTS_CONFIGURATION,
+
+            // Camera lens
+            ExifInterface.TAG_LENS_MAKE,
+            ExifInterface.TAG_LENS_MODEL,
+            ExifInterface.TAG_LENS_SERIAL_NUMBER,
+            ExifInterface.TAG_LENS_SPECIFICATION,
+            ExifInterface.TAG_BODY_SERIAL_NUMBER,
+            ExifInterface.TAG_CAMERA_OWNER_NAME,
+
+            // Image identifiers
+            ExifInterface.TAG_IMAGE_UNIQUE_ID,
+
+            // GPS
+            ExifInterface.TAG_GPS_VERSION_ID,
+            ExifInterface.TAG_GPS_LATITUDE,
+            ExifInterface.TAG_GPS_LATITUDE_REF,
+            ExifInterface.TAG_GPS_LONGITUDE,
+            ExifInterface.TAG_GPS_LONGITUDE_REF,
+            ExifInterface.TAG_GPS_ALTITUDE,
+            ExifInterface.TAG_GPS_ALTITUDE_REF,
+            ExifInterface.TAG_GPS_TIMESTAMP,
+            ExifInterface.TAG_GPS_DATESTAMP,
+            ExifInterface.TAG_GPS_SATELLITES,
+            ExifInterface.TAG_GPS_STATUS,
+            ExifInterface.TAG_GPS_MEASURE_MODE,
+            ExifInterface.TAG_GPS_DOP,
+            ExifInterface.TAG_GPS_SPEED,
+            ExifInterface.TAG_GPS_SPEED_REF,
+            ExifInterface.TAG_GPS_TRACK,
+            ExifInterface.TAG_GPS_TRACK_REF,
+            ExifInterface.TAG_GPS_IMG_DIRECTION,
+            ExifInterface.TAG_GPS_IMG_DIRECTION_REF,
+            ExifInterface.TAG_GPS_MAP_DATUM,
+            ExifInterface.TAG_GPS_DEST_LATITUDE,
+            ExifInterface.TAG_GPS_DEST_LATITUDE_REF,
+            ExifInterface.TAG_GPS_DEST_LONGITUDE,
+            ExifInterface.TAG_GPS_DEST_LONGITUDE_REF,
+            ExifInterface.TAG_GPS_DEST_BEARING,
+            ExifInterface.TAG_GPS_DEST_BEARING_REF,
+            ExifInterface.TAG_GPS_DEST_DISTANCE,
+            ExifInterface.TAG_GPS_DEST_DISTANCE_REF,
+            ExifInterface.TAG_GPS_PROCESSING_METHOD,
+            ExifInterface.TAG_GPS_AREA_INFORMATION,
+            ExifInterface.TAG_GPS_DIFFERENTIAL,
+            ExifInterface.TAG_GPS_H_POSITIONING_ERROR
     );
 
     private final ExifInterface oldExif;
@@ -54,6 +155,13 @@ public class ExifKeeper {
         for (String attribute : attributes) {
             setIfNotNull(oldExif, newExif, attribute);
         }
+        // Output pixels are re-encoded in display orientation by the pipeline
+        // (BitmapFactory decode + optional Bitmap.rotate before compress), so the
+        // source's TAG_ORIENTATION must not carry over — otherwise viewers double-rotate.
+        newExif.setAttribute(
+                ExifInterface.TAG_ORIENTATION,
+                String.valueOf(ExifInterface.ORIENTATION_NORMAL)
+        );
         try {
             newExif.saveAttributes();
         } catch (IOException ignored) {
@@ -69,9 +177,10 @@ public class ExifKeeper {
     public ByteArrayOutputStream writeToOutputStream(Context context, ByteArrayOutputStream outputStream) {
         FileOutputStream fileOutputStream = null;
         FileInputStream fileInputStream = null;
+        File file = null;
         try {
             String uuid = UUID.randomUUID().toString();
-            File file = new File(context.getCacheDir(), uuid + ".jpg");
+            file = new File(context.getCacheDir(), uuid + ".jpg");
             fileOutputStream = new FileOutputStream(file);
             IOUtils.write(outputStream.toByteArray(), fileOutputStream);
             fileOutputStream.close();
@@ -86,19 +195,24 @@ public class ExifKeeper {
             return newStream;
         } catch (Exception ex) {
             Log.e("ExifDataCopier", "Error preserving Exif data on selected image: " + ex);
-        }
-        if (fileInputStream != null) {
-            try {
-                fileInputStream.close();
-            } catch (IOException e) {
-                e.printStackTrace();
+        } finally {
+            if (fileInputStream != null) {
+                try {
+                    fileInputStream.close();
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
             }
-        }
-        if (fileOutputStream != null) {
-            try {
-                fileOutputStream.close();
-            } catch (IOException e) {
-                e.printStackTrace();
+            if (fileOutputStream != null) {
+                try {
+                    fileOutputStream.close();
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            }
+            if (file != null) {
+                //noinspection ResultOfMethodCallIgnored
+                file.delete();
             }
         }
         return outputStream;


### PR DESCRIPTION
## Summary
- Fixes #159 (Exif data lost on Android even with `keepExif=true`) and #185 (JPEG EXIF getting removed / modified).
- Partial for #321 (tmp file leak — closes the Android side of it).

`ExifKeeper.java` had three problems:

1. **Hard-coded 18-tag preservation list.** Everything users reported as missing (DateTimeOriginal, Orientation, XResolution/YResolution/ResolutionUnit, ExifVersion, MeteringMode, ExposureProgram, ShutterSpeedValue, Aperture, all subsec+offset time, most GPS, lens make/model, …) was silently dropped. Expanded to ~85 `ExifInterface.TAG_*` compile-time constants — descriptive/authorship, orientation+resolution, dates (subsec + offset), full exposure/capture parameters, EXIF+Flashpix versions, color space, full lens block, image unique ID, and the full GPS block. Tags invalidated by re-encoding (image/pixel dims, JPEG structural, thumbnail pointers) stay excluded.

2. **`TAG_ORIENTATION` double-rotation regression.** The Android pipeline bakes rotation into the pixels (`BitmapFactory` decode + optional `Bitmap.rotate` before compress). If we preserved the source's `Rotated 90 CW`, viewers honoring EXIF orientation would double-rotate. After `copyExif`, we now explicitly force `TAG_ORIENTATION = ORIENTATION_NORMAL` so the metadata stays truthful for both `autoCorrectionAngle=true` and `=false`.

3. **Tmp `.jpg` file leak.** `writeToOutputStream` wrote compressed bytes to `<cacheDir>/<uuid>.jpg`, re-read them, and never deleted the file. Every `keepExif=true` call leaked one file. Consolidated cleanup into a `finally` block that closes both streams and deletes the tmp file on all paths.

## Test plan
- [x] Adversarial verifier caught and confirmed the `TAG_ORIENTATION` double-rotation risk before ship; explicit `ORIENTATION_NORMAL` overwrite added in the same file.
- [x] All ~85 tags reference `ExifInterface.TAG_*` constants pinned in `androidx.exifinterface 1.3.3` (verified via `build.gradle`).
- [x] `IOUtils.copy` finishes draining the file into the in-memory `newStream` before the `finally` deletes the source — output preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)