### PR TITLE
fix(iOS): delete HEIC intermediate tmp file after read-back (#321 partial)

### DIFF
--- a/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/CompressHandler.m
+++ b/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/CompressHandler.m
@@ -52,24 +52,23 @@
         CIImage *ciImage = [CIImage imageWithCGImage:image.CGImage];
         CIContext *ciContext = [[CIContext alloc]initWithOptions:nil];
         NSString *tmpDir = NSTemporaryDirectory();
-        double time = [[NSDate alloc]init].timeIntervalSince1970;
-        NSString *target = [NSString stringWithFormat:@"%@%.0f.heic",tmpDir, time * 1000];
+        NSString *target = [NSString stringWithFormat:@"%@%@.heic", tmpDir, [[NSUUID UUID] UUIDString]];
         NSURL *url = [NSURL fileURLWithPath:target];
-        
+
         NSMutableDictionary *options = [NSMutableDictionary new];
         NSString *qualityKey = (__bridge NSString *)kCGImageDestinationLossyCompressionQuality;
 //        CIImageRepresentationOption
         [options setObject:@(quality / 100) forKey: qualityKey];
-        
+
         if (@available(iOS 11.0, *)) {
             CGColorSpaceRef colorSpace = ciImage.colorSpace;
             if (colorSpace == NULL) {
                 colorSpace = CGColorSpaceCreateWithName(kCGColorSpaceSRGB);
             }
-            
+
             NSError *error = nil;
             BOOL success = [ciContext writeHEIFRepresentationOfImage:ciImage toURL:url format:kCIFormatARGB8 colorSpace:colorSpace options:options error:&error];
-            
+
             if (success) {
                 data = [NSData dataWithContentsOfURL:url];
             } else {
@@ -78,10 +77,14 @@
                     NSLog(@"HEIC write failed: %@", error.localizedDescription);
                 }
             }
-            
+
             if (colorSpace != ciImage.colorSpace) {
                 CGColorSpaceRelease(colorSpace);
             }
+
+            // Always attempt cleanup; ignore errors (file may already be gone
+            // or may have been partially written on failure).
+            [[NSFileManager defaultManager] removeItemAtURL:url error:nil];
         } else {
             // Fallback on earlier versions
             data = nil;


### PR DESCRIPTION
## Summary
- Partial fix for #321.
- `CompressHandler.m`'s HEIC branch (`format == 2`) wrote the CIContext output to `NSTemporaryDirectory()/<timestamp>.heic`, read it back with `[NSData dataWithContentsOfURL:]`, and never removed the file. Every HEIC compression left one artifact behind — over time this piles up because iOS' NSTemporaryDirectory cleanup is not immediate.
- Switch the filename from `time * 1000` (ms precision, collision-prone under concurrent calls) to `[[NSUUID UUID] UUIDString]`.
- Remove the file unconditionally after the read-back (both success and failure branches). `removeItemAtURL:error:nil` is a no-op if the file was never created.

## Test plan
- [x] Cleanup runs inside the `@available(iOS 11.0, *)` block, so the iOS <11 fallback (which never writes a file) is unaffected.
- [x] `CGColorSpaceRelease` on the fallback-created colorSpace is preserved and still runs before the deletion.
- [x] No other tmp writes in the file — JPEG/PNG/WebP branches all use in-memory encoders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)