### PR TITLE
fix(dart): give UnsupportedFlutterImageCompress actionable error messages (#250 #303 #235)

### DIFF
--- a/packages/flutter_image_compress_platform_interface/lib/flutter_image_compress_platform_interface.dart
+++ b/packages/flutter_image_compress_platform_interface/lib/flutter_image_compress_platform_interface.dart
@@ -10,6 +10,15 @@ export 'src/errors.dart';
 export 'src/validator.dart';
 export 'package:cross_file/cross_file.dart';
 
+const _kUnsupportedHint = '\n\nCommon causes:\n'
+    '  * Calling from a background Isolate - either move to the main '
+    'isolate, or call BackgroundIsolateBinaryMessenger.ensureInitialized(...) '
+    'inside the isolate before use.\n'
+    '  * No implementation registered for the current platform (Windows is '
+    'not supported; for Linux, add package:flutter_image_compress_linux).\n'
+    '  * Release/minified web build where platform detection fails - try '
+    'flutter build web --profile to confirm.';
+
 abstract class FlutterImageCompressPlatform extends PlatformInterface {
   static const _token = Object();
 
@@ -85,7 +94,10 @@ class UnsupportedFlutterImageCompress extends FlutterImageCompressPlatform {
       bool autoCorrectionAngle = true,
       CompressFormat format = CompressFormat.jpeg,
       bool keepExif = false}) {
-    throw UnimplementedError();
+    throw UnimplementedError(
+      'FlutterImageCompress.compressAssetImage is not available.'
+      '$_kUnsupportedHint',
+    );
   }
 
   @override
@@ -99,7 +111,10 @@ class UnsupportedFlutterImageCompress extends FlutterImageCompressPlatform {
       CompressFormat format = CompressFormat.jpeg,
       bool keepExif = false,
       int numberOfRetries = 5}) {
-    throw UnimplementedError();
+    throw UnimplementedError(
+      'FlutterImageCompress.compressWithFile is not available.'
+      '$_kUnsupportedHint',
+    );
   }
 
   @override
@@ -113,7 +128,10 @@ class UnsupportedFlutterImageCompress extends FlutterImageCompressPlatform {
       CompressFormat format = CompressFormat.jpeg,
       bool keepExif = false,
       int numberOfRetries = 5}) {
-    throw UnimplementedError();
+    throw UnimplementedError(
+      'FlutterImageCompress.compressAndGetFile is not available.'
+      '$_kUnsupportedHint',
+    );
   }
 
   @override
@@ -126,19 +144,31 @@ class UnsupportedFlutterImageCompress extends FlutterImageCompressPlatform {
       bool autoCorrectionAngle = true,
       CompressFormat format = CompressFormat.jpeg,
       bool keepExif = false}) {
-    throw UnimplementedError();
+    throw UnimplementedError(
+      'FlutterImageCompress.compressWithList is not available.'
+      '$_kUnsupportedHint',
+    );
   }
 
   @override
   Future<void> showNativeLog(bool value) {
-    throw UnimplementedError();
+    throw UnimplementedError(
+      'FlutterImageCompress.showNativeLog is not available.'
+      '$_kUnsupportedHint',
+    );
   }
 
   @override
   void ignoreCheckSupportPlatform(bool bool) {
-    throw UnimplementedError();
+    throw UnimplementedError(
+      'FlutterImageCompress.ignoreCheckSupportPlatform is not available.'
+      '$_kUnsupportedHint',
+    );
   }
 
   @override
-  FlutterImageCompressValidator get validator => throw UnimplementedError();
+  FlutterImageCompressValidator get validator => throw UnimplementedError(
+        'FlutterImageCompress.validator is not available.'
+        '$_kUnsupportedHint',
+      );
 }


### PR DESCRIPTION
## Summary
- Fixes #250, #303, #235.
- `UnsupportedFlutterImageCompress` used to throw bare `UnimplementedError()` from 7 sites (6 methods + the `validator` getter). That's what users see when:
  1. They call the plugin from a background `Isolate` without invoking `BackgroundIsolateBinaryMessenger.ensureInitialized(...)` first (#250, #235).
  2. They run on a platform with no implementation registered (Windows still has none; Linux now has `flutter_image_compress_linux`).
  3. A release/minified web build fails platform detection and falls through to this fallback (#303, historically also #304).
- Replace each site with a method-named message and a shared `_kUnsupportedHint` const that points at these three causes — so the exception message itself tells users what to fix without a GitHub search.
- Signatures, return types, imports, and the constructor call on line 26 are all unchanged.

## Test plan
- [x] Exactly 7 throw sites updated (grep confirmed).
- [x] `dart format` clean; no line exceeds 80 columns.
- [x] No existing test asserts on the specific `UnimplementedError` message; type is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)