### PR TITLE
fix(Android): delete HEIC tmp file + cache CI deps (#321 partial)

### DIFF
--- a/.github/workflows/runnable.yml
+++ b/.github/workflows/runnable.yml
@@ -24,10 +24,27 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: "stable"
+          cache: true
       - name: Log Dart/Flutter versions
         run: |
           dart --version
           flutter --version
+      - name: Cache pub git deps
+        uses: actions/cache@v4
+        with:
+          path: ~/.pub-cache/git
+          key: ${{ runner.os }}-pub-git-${{ hashFiles('**/pubspec.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pub-git-
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
       - name: Install melos
         run: dart pub global activate melos
       - name: Melos bootstrap
@@ -56,8 +73,27 @@ jobs:
         with:
           architecture: x64
           channel: "stable"
+          cache: true
       - run: dart --version
       - run: flutter --version
+      - name: Cache pub git deps
+        uses: actions/cache@v4
+        with:
+          path: ~/.pub-cache/git
+          key: ${{ runner.os }}-pub-git-${{ hashFiles('**/pubspec.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pub-git-
+      - name: Cache CocoaPods
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/Library/Caches/CocoaPods
+            ~/.cocoapods
+            packages/flutter_image_compress/example/ios/Pods
+            packages/flutter_image_compress/example/macos/Pods
+          key: ${{ runner.os }}-pods-${{ hashFiles('**/Podfile.lock', '**/Podfile') }}
+          restore-keys: |
+            ${{ runner.os }}-pods-
       - name: Install melos
         run: dart pub global activate melos
       - name: Melos bootstrap
@@ -80,7 +116,26 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: "stable"
+          cache: true
       - run: flutter --version
+      - name: Cache pub git deps
+        uses: actions/cache@v4
+        with:
+          path: ~/.pub-cache/git
+          key: ${{ runner.os }}-pub-git-${{ hashFiles('**/pubspec.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pub-git-
+      - name: Cache CocoaPods
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/Library/Caches/CocoaPods
+            ~/.cocoapods
+            packages/flutter_image_compress/example/ios/Pods
+            packages/flutter_image_compress/example/macos/Pods
+          key: ${{ runner.os }}-pods-${{ hashFiles('**/Podfile.lock', '**/Podfile') }}
+          restore-keys: |
+            ${{ runner.os }}-pods-
       - name: Install melos
         run: dart pub global activate melos
       - name: Melos bootstrap
@@ -135,7 +190,26 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: "stable"
+          cache: true
       - run: flutter --version
+      - name: Cache pub git deps
+        uses: actions/cache@v4
+        with:
+          path: ~/.pub-cache/git
+          key: ${{ runner.os }}-pub-git-${{ hashFiles('**/pubspec.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pub-git-
+      - name: Cache CocoaPods
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/Library/Caches/CocoaPods
+            ~/.cocoapods
+            packages/flutter_image_compress/example/ios/Pods
+            packages/flutter_image_compress/example/macos/Pods
+          key: ${{ runner.os }}-pods-${{ hashFiles('**/Podfile.lock', '**/Podfile') }}
+          restore-keys: |
+            ${{ runner.os }}-pods-
       - name: Install melos
         run: dart pub global activate melos
       - name: Melos bootstrap
@@ -167,8 +241,25 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: "stable"
+          cache: true
       - run: dart --version
       - run: flutter --version
+      - name: Cache pub git deps
+        uses: actions/cache@v4
+        with:
+          path: ~/.pub-cache/git
+          key: ${{ runner.os }}-pub-git-${{ hashFiles('**/pubspec.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pub-git-
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
       - run: flutter pub get
       - name: Install melos
         run: dart pub global activate melos
@@ -192,8 +283,16 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: "stable"
+          cache: true
       - run: dart --version
       - run: flutter --version
+      - name: Cache pub git deps
+        uses: actions/cache@v4
+        with:
+          path: ~/.pub-cache/git
+          key: ${{ runner.os }}-pub-git-${{ hashFiles('**/pubspec.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pub-git-
       - name: Install melos
         run: dart pub global activate melos
       - name: Melos bootstrap

--- a/packages/flutter_image_compress_common/android/src/main/kotlin/com/fluttercandies/flutter_image_compress/handle/heif/HeifHandler.kt
+++ b/packages/flutter_image_compress_common/android/src/main/kotlin/com/fluttercandies/flutter_image_compress/handle/heif/HeifHandler.kt
@@ -30,8 +30,12 @@ class HeifHandler : FormatHandler {
         inSampleSize: Int
     ) {
         val tmpFile = TmpFileUtil.createTmpFile(context)
-        compress(byteArray, minWidth, minHeight, quality, rotate, inSampleSize, tmpFile.absolutePath)
-        outputStream.write(tmpFile.readBytes())
+        try {
+            compress(byteArray, minWidth, minHeight, quality, rotate, inSampleSize, tmpFile.absolutePath)
+            outputStream.write(tmpFile.readBytes())
+        } finally {
+            tmpFile.delete()
+        }
     }
 
     private fun compress(
@@ -123,7 +127,11 @@ class HeifHandler : FormatHandler {
         numberOfRetries: Int
     ) {
         val tmpFile = TmpFileUtil.createTmpFile(context)
-        compress(path, minWidth, minHeight, quality, rotate, inSampleSize, tmpFile.absolutePath)
-        outputStream.write(tmpFile.readBytes())
+        try {
+            compress(path, minWidth, minHeight, quality, rotate, inSampleSize, tmpFile.absolutePath)
+            outputStream.write(tmpFile.readBytes())
+        } finally {
+            tmpFile.delete()
+        }
     }
 }


### PR DESCRIPTION
## Summary

Two related changes that ship together.

### Android HEIC tmp-file leak (partial #321)

Mirrors the iOS side that landed in #377. `HeifHandler.handleByteArray` and `handleFile` each create a tmp file via `TmpFileUtil.createTmpFile(context)` (HeifWriter needs a real path — it can't stream), and never delete it after copying the bytes into the caller's `OutputStream`. Every HEIC compression leaks one artifact in the app cache dir.

Wrapped both sites in `try { compress + copy } finally { tmpFile.delete() }`. `File.delete()` is idempotent (no-throw on missing file), so cleanup runs safely on both success and exception paths.

### CI cache layers (`runnable.yml`)

The recurring `git clone --mirror https://gitee.com/openharmony-sig/flutter_packages.git` transient (~2 GB fetch that resets mid-stream) has been the dominant CI failure mode across the recent PRs. Every fresh runner re-clones the OpenHarmony mirror to resolve `path_provider_ohos` in the example app. Added:

- `cache: true` on `subosito/flutter-action` — Flutter SDK + `~/.pub-cache/hosted`
- `actions/cache@v4` on `~/.pub-cache/git` keyed on `pubspec.yaml` hash — populates the gitee mirror once, reuses it thereafter. Applied to every job.
- `actions/cache@v4` on `~/.gradle/{caches,wrapper}` for the `analyze` and `test_android` jobs
- `actions/cache@v4` on CocoaPods (`~/Library/Caches/CocoaPods`, `~/.cocoapods`, example `ios/Pods`, example `macos/Pods`) for the `test_iOS`, `integration_test_iOS`, `integration_test_macOS` jobs

`restore-keys` fall-through gives cross-branch reuse — most pubspec changes don't affect the OHOS git dep, so once one branch's cache is warm every subsequent run skips the gitee clone entirely.

## Cache matrix

| Job | flutter-action cache | pub-git | Gradle | CocoaPods |
|---|---|---|---|---|
| analyze | ✅ | ✅ | ✅ | – |
| test_iOS | ✅ | ✅ | – | ✅ |
| integration_test_iOS | ✅ | ✅ | – | ✅ |
| integration_test_macOS | ✅ | ✅ | – | ✅ |
| test_android | ✅ | ✅ | ✅ | – |
| test_web | ✅ | ✅ | – | – |

## Test plan

- [x] `HeifHandler.kt` diff is symmetric between `handleByteArray` and `handleFile`; `finally` runs before any thrown exception propagates.
- [x] Every job now has appropriate cache steps in the correct position (after `flutter-action`, before `melos bootstrap`).
- [x] First-run warm-up on this branch will still hit gitee once to populate the cache. Subsequent CI runs (retries, rebases, other PRs) should skip the mirror clone entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
