### PR TITLE
fix(iOS): detect HEIC/HEIF/AVIF via ISO BMFF ftyp box in mime sniffer

### DIFF
--- a/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/CompressFileHandler.m
+++ b/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/CompressFileHandler.m
@@ -193,6 +193,23 @@
         return @"image/jp2";
     }
 
+    // ISO BMFF (HEIC/HEIF/AVIF) — box at bytes 0-7 is [size][ftyp], brand at bytes 8-11.
+    const char ftyp[4] = {'f', 't', 'y', 'p'};
+    if (!memcmp(bytes + 4, ftyp, 4)) {
+        const char *brand = bytes + 8;
+        if (!memcmp(brand, "heic", 4) || !memcmp(brand, "heix", 4) || !memcmp(brand, "hevc", 4)) {
+            return @"image/heic";
+        }
+        if (!memcmp(brand, "mif1", 4) || !memcmp(brand, "msf1", 4)) {
+            return @"image/heif";
+        }
+        if (!memcmp(brand, "avif", 4) || !memcmp(brand, "avis", 4)) {
+            return @"image/avif";
+        }
+        // Unknown ISO BMFF brand (e.g. MP4/MOV — same container, not an image).
+        // Fall through so the octet-stream diagnostic still reflects reality.
+    }
+
     return @"application/octet-stream"; // default type
 
 }


### PR DESCRIPTION
## Summary
- `mimeTypeByGuessingFromData:` classified HEIC / HEIF / AVIF files as `application/octet-stream` because they don't have a 3/4-byte magic prefix at offset 0 — they use an ISO BMFF `ftyp` box at bytes 4-7 followed by a brand at bytes 8-11.
- Add the missing ISO BMFF check right before the octet-stream fallback:
  - `heic` / `heix` / `hevc` → `image/heic`
  - `mif1` / `msf1` → `image/heif`
  - `avif` / `avis` → `image/avif`
- Unknown ISO BMFF brands (MP4/MOV/etc.) intentionally fall through to `application/octet-stream` so the round-2 non-image reject log in #374 still reflects reality for actual video inputs.

## Downstream effect

Strictly additive. Downstream only tests `imageType isEqual:@"image/webp"`, so existing branching is unaffected. The improvement is diagnostic: when a real HEIC input hits the `img == nil` guard from #374, the log message now says `mime=image/heic` instead of `mime=application/octet-stream`.

## Test plan

- [x] Existing detection order (BMP/GIF/JPEG/PSD/IFF/WebP/ICO/TIFF/PNG/JP2) unchanged.
- [x] Non-image ISO BMFF (MP4/MOV) falls through to `application/octet-stream` so the round-2 video-reject diagnostic stays accurate.
- [x] `[UIImage imageWithData:]` handles HEIC/HEIF natively on iOS 11+; no encode/decode path change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)