### PR TITLE
fix(Android): recycle intermediate bitmaps in scale/rotate pipeline (#77 #80 partial)

### DIFF
--- a/packages/flutter_image_compress_common/android/src/main/kotlin/com/fluttercandies/flutter_image_compress/ext/BitmapCompressExt.kt
+++ b/packages/flutter_image_compress_common/android/src/main/kotlin/com/fluttercandies/flutter_image_compress/ext/BitmapCompressExt.kt
@@ -32,11 +32,20 @@ fun Bitmap.compress(
     val destH = h / scale
     log("dst width = $destW")
     log("dst height = $destH")
-    Bitmap.createScaledBitmap(
-        this,
-        destW.toInt(),
-        destH.toInt(), true
-    ).rotate(rotate).compress(convertFormatIndexToFormat(format), quality, outputStream)
+    val scaled = Bitmap.createScaledBitmap(this, destW.toInt(), destH.toInt(), true)
+    val rotated = scaled.rotate(rotate)
+    try {
+        rotated.compress(convertFormatIndexToFormat(format), quality, outputStream)
+    } finally {
+        // Recycle in reverse order, but only when the instance is distinct
+        // from its parent (createScaledBitmap and rotate can pass-through).
+        if (rotated !== scaled) {
+            rotated.recycle()
+        }
+        if (scaled !== this) {
+            scaled.recycle()
+        }
+    }
 }
 
 private fun log(any: Any?) {


### PR DESCRIPTION
## Summary
- Partially addresses #77 and #80 — Android OOM reports on large images.
- `BitmapCompressExt.Bitmap.compress(...)` built its output through the fluent chain
  ```kotlin
  Bitmap.createScaledBitmap(this, ..., true).rotate(rotate).compress(...)
  ```
  and never recycled the intermediate bitmaps. Each intermediate holds a native pixel buffer (~48 MB for a 4032×3024 ARGB_8888 image after the round-2 config change); they sit until GC.
- Hold the intermediates in named refs, wrap `compress(...)` in try/finally, and recycle each intermediate in the finally block — with identity guards (`!==`) so we don't recycle the caller's own bitmap in the "no scale needed" / "no rotate needed" pass-through cases.

## Test plan
- [x] `scaled !== this` guard handles the `createScaledBitmap` pass-through case (documented AOSP behavior when dst dims match src dims).
- [x] `rotated !== scaled` guard handles the `rotate()` pass-through case (`if (rotate % 360 == 0) this else createBitmap(...)`).
- [x] `finally` runs even if `Bitmap.compress` throws — no leak on error paths.
- [x] The shorter `compress` overload delegates to this longer one, so it inherits the fix.
- [x] `rotate()`, `calcScale()`, and other helpers untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)