### PR TITLE
fix(dart): validator throws in release + names the offending path (#189 #247)

### DIFF
--- a/packages/flutter_image_compress_platform_interface/lib/src/validator.dart
+++ b/packages/flutter_image_compress_platform_interface/lib/src/validator.dart
@@ -17,27 +17,35 @@ class FlutterImageCompressValidator {
     if (ignoreCheckExtName) {
       return;
     }
-    name = name.toLowerCase();
+    final lower = name.toLowerCase();
+    late final Iterable<String> allowedExts;
+    late final String formatLabel;
     if (format == CompressFormat.jpeg) {
-      assert(
-        (name.endsWith('.jpg') || name.endsWith('.jpeg')),
-        'The jpeg format name must end with jpg or jpeg.',
-      );
+      allowedExts = const ['.jpg', '.jpeg'];
+      formatLabel = 'jpeg';
     } else if (format == CompressFormat.png) {
-      assert(
-        name.endsWith('.png'),
-        'The png format name must end with png.',
-      );
+      allowedExts = const ['.png'];
+      formatLabel = 'png';
     } else if (format == CompressFormat.heic) {
-      assert(
-        name.endsWith('.heic'),
-        'The heic format name must end with heic.',
-      );
+      allowedExts = const ['.heic'];
+      formatLabel = 'heic';
     } else if (format == CompressFormat.webp) {
-      assert(
-        name.endsWith('.webp'),
-        'The webp format name must end with webp.',
-      );
+      allowedExts = const ['.webp'];
+      formatLabel = 'webp';
+    } else {
+      return;
+    }
+    final ok = allowedExts.any(lower.endsWith);
+    if (!ok) {
+      final expected = allowedExts.join(' or ');
+      final msg =
+          'CompressFormat.$formatLabel requires the target file name to end '
+          'with $expected. Got: "$name". '
+          'If you deliberately want to bypass this check (for example the '
+          'target extension does not match the encoded format), set '
+          'FlutterImageCompress.validator.ignoreCheckExtName = true.';
+      assert(false, msg);
+      throw ArgumentError.value(name, 'name', msg);
     }
   }
 


### PR DESCRIPTION
## Summary
- Fixes #189, #247.
- `FlutterImageCompressValidator.checkFileNameAndFormat` used bare `assert(name.endsWith(...))`. `assert` is stripped from release builds, so a wrong extension slid straight through to native — either producing a bogus file or failing opaquely later. The message also didn't include the offending value, so the classic mistake in #189 (passing `Directory.current.path` — a directory — as the target file) surfaced as the cryptic "The png format name must end with png."
- Rewrite the check to build an `allowedExts` list per format, compare once, and on failure emit a message that
  1. names the offending value (`Got: "$name"`),
  2. points at `FlutterImageCompress.validator.ignoreCheckExtName = true` for the intentional-bypass path (currently only discoverable by reading source),
  3. fires both `assert(false, msg)` for debug parity **and** `throw ArgumentError.value(name, 'name', msg)` so release builds no longer silently pass.
- Public API is unchanged (same method signature, same `ignoreCheckExtName` short-circuit).

## Test plan
- [x] SDK constraint `>=2.12.0 <4.0.0` respected — used if/else chain instead of Dart 3 switch expression, and hard-coded `formatLabel` strings instead of `enum.name` (which needs 2.15+).
- [x] No callers assert on the old message text.
- [x] `dart format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)