### PR TITLE
fix(web): honor minHeight in resizeWithList (match native calcScale)

### DIFF
--- a/packages/flutter_image_compress_web/lib/src/compressor.dart
+++ b/packages/flutter_image_compress_web/lib/src/compressor.dart
@@ -1,6 +1,7 @@
 library pica;
 
 import 'dart:convert';
+import 'dart:math' as math;
 import 'dart:typed_data';
 
 import 'package:flutter_image_compress_platform_interface/flutter_image_compress_platform_interface.dart';
@@ -22,10 +23,13 @@ Future<Uint8List> resizeWithList({
   final srcWidth = bitmap.width;
   final srcHeight = bitmap.height;
 
-  final ratio = srcWidth / srcHeight;
-
-  final width = srcWidth > minWidth ? minWidth : srcWidth;
-  final height = width ~/ ratio;
+  final scaleW = srcWidth / minWidth;
+  final scaleH = srcHeight / minHeight;
+  // Take the smaller downscale factor so at least one output dimension
+  // meets its min bound; clamp at 1 so we never upscale.
+  final scale = math.max(1.0, math.min(scaleW, scaleH));
+  final width = (srcWidth / scale).toInt();
+  final height = (srcHeight / scale).toInt();
 
   logger.jsLog('src size', '$srcWidth x $srcHeight');
   logger.jsLog('target size', '$width x $height');


### PR DESCRIPTION
## Summary
- `resizeWithList` in the Web implementation only checked `srcWidth > minWidth` and derived height from a stored aspect ratio — `minHeight` was silently ignored. That produced smaller outputs than native for landscape sources with tight width bounds:
  - source **4032×3024**, `minWidth: 1920, minHeight: 1920`
    - Web (before): **1920×1440** (height was allowed to fall below `minHeight`)
    - Native Android/iOS: **2560×1920** (both bounds honored, width overshoots)
- Rewrite the resize math to mirror the native `calcScale` in `BitmapCompressExt.kt`:
  ```dart
  final scale = math.max(1.0, math.min(srcWidth / minWidth, srcHeight / minHeight));
  final width  = (srcWidth  / scale).toInt();
  final height = (srcHeight / scale).toInt();
  ```
  `.toInt()` truncation matches Kotlin's `Float.toInt()`. The `max(1, ...)` clamp preserves the "never upscale" invariant.

## Verified cases (native parity)
| source | minW×minH | native | web after this PR |
|---|---|---|---|
| 4032×3024 | 1920×1920 | 2560×1920 | 2560×1920 |
| 400×1000 | 200×100 | 200×500 | 200×500 |
| 800×600 | 1920×1080 | 800×600 (no upscale) | 800×600 |
| 1000×1000 | 500×500 | 500×500 | 500×500 |

## Test plan
- [x] Aligns with the same rationale documented in the new FAQ (#384) — "minWidth/minHeight are aspect-preserving upper bounds".
- [x] `dart:math` imported exactly once.
- [x] No changes to the canvas / toDataUrl chain or the `CompressExt` MIME map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)