### PR TITLE
fix(dart): reject compressAndGetFile when source == target (#240)

### DIFF
--- a/packages/flutter_image_compress/lib/flutter_image_compress.dart
+++ b/packages/flutter_image_compress/lib/flutter_image_compress.dart
@@ -102,6 +102,21 @@ class FlutterImageCompress {
     bool keepExif = false,
     int numberOfRetries = 5,
   }) async {
+    // Guard against source and target resolving to the same file. The native
+    // Android/iOS handlers open the target for writing (truncating it) before
+    // they read the source, so a same-path call would silently corrupt the
+    // source before compression could read it.
+    final normalizedSource = Uri.file(path).normalizePath().toFilePath();
+    final normalizedTarget = Uri.file(targetPath).normalizePath().toFilePath();
+    if (normalizedSource == normalizedTarget) {
+      throw ArgumentError.value(
+        targetPath,
+        'targetPath',
+        'compressAndGetFile source and targetPath resolve to the same file '
+            '($normalizedSource). Use compressWithFile to get bytes only, or '
+            'pass a different targetPath.',
+      );
+    }
     return _platform.compressAndGetFile(
       path,
       targetPath,


### PR DESCRIPTION
## Summary
- Fixes #240.
- The native Android / iOS / macOS handlers open `targetPath` for writing (which truncates it) **before** reading the source. When a caller passes the same path for source and target, the write clobbers the source before compression can read it — the caller gets a zero-byte "success" file with no diagnostic.
- Guard at the umbrella package's `FlutterImageCompress.compressAndGetFile` — one Dart-side check covers **every platform**, catches the mistake before it hits the platform channel, and matches the release-mode `ArgumentError` pattern established by #383 (validator).

## Path normalization

Uses `Uri.file(path).normalizePath().toFilePath()`:
- Handles `./` and `../` reliably.
- Does **not** touch the filesystem — no `existsSync()` requirement, so it works whether the target file already exists or not.
- Cross-platform (Android POSIX paths, iOS/macOS POSIX paths, Windows drive-letter paths — all handled by Dart's `Uri.file`).

## Test plan
- [x] Guard runs at the Dart entry point, before `_platform.compressAndGetFile(...)`.
- [x] Throws `ArgumentError.value` with the offending value and a helpful hint pointing at `compressWithFile` for the byte-only alternative.
- [x] No native-side changes needed — behavior is uniform across all platforms.
- [x] `compressWithFile` (byte-only) intentionally not guarded; there's no target file to clobber.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
