### PR TITLE
fix(Android): recycle HEIC bitmaps and always close HeifWriter (#136 partial)

### DIFF
--- a/packages/flutter_image_compress_common/android/src/main/kotlin/com/fluttercandies/flutter_image_compress/handle/heif/HeifHandler.kt
+++ b/packages/flutter_image_compress_common/android/src/main/kotlin/com/fluttercandies/flutter_image_compress/handle/heif/HeifHandler.kt
@@ -96,22 +96,36 @@ class HeifHandler : FormatHandler {
         val destH = h / scale
         log("dst width = $destW")
         log("dst height = $destH")
-        val result = Bitmap.createScaledBitmap(
+        val scaled = Bitmap.createScaledBitmap(
             bitmap,
             destW.toInt(),
             destH.toInt(),
             true
-        ).rotate(rotate)
-        val heifWriter = HeifWriter.Builder(
-            targetPath,
-            result.width,
-            result.height,
-            HeifWriter.INPUT_MODE_BITMAP
-        ).setQuality(quality).setMaxImages(1).build()
-        heifWriter.start()
-        heifWriter.addBitmap(result)
-        heifWriter.stop(5000)
-        heifWriter.close()
+        )
+        val result = scaled.rotate(rotate)
+        try {
+            val heifWriter = HeifWriter.Builder(
+                targetPath,
+                result.width,
+                result.height,
+                HeifWriter.INPUT_MODE_BITMAP
+            ).setQuality(quality).setMaxImages(1).build()
+            try {
+                heifWriter.start()
+                heifWriter.addBitmap(result)
+                heifWriter.stop(5000)
+            } finally {
+                heifWriter.close()
+            }
+        } finally {
+            if (result !== scaled) {
+                result.recycle()
+            }
+            if (scaled !== bitmap) {
+                scaled.recycle()
+            }
+            bitmap.recycle()
+        }
     }
 
     override fun handleFile(


### PR DESCRIPTION
## Summary
- Partially addresses #136 (Android "A resource failed to call close" logcat) and continues the #382 memory-pressure work into the HEIC path.
- `HeifHandler.convertToHeif` built its intermediates through the fluent chain `createScaledBitmap(bitmap, ...).rotate(rotate)` and never recycled either the scaled buffer, the rotated buffer, or the source `bitmap` parameter. On ARGB_8888 4032×3024 that's ~48 MB per bitmap; camera-driven HEIC pipelines pile those up.
- `HeifWriter.start/addBitmap/stop` can all throw (stop is documented to time out after the given wall-clock — 5s here). When any threw, `heifWriter.close()` on the next line was skipped and the underlying MediaMuxer / encoder was left uncleaned.

## Fix

Two nested try/finally, mirroring the #382 pattern for the JPEG/PNG/WebP path:

- Outer try/finally wraps the whole HEIC write. In the finally, `result`, `scaled`, and the source `bitmap` are recycled in reverse allocation order, with `!==` identity guards so `createScaledBitmap` / `rotate` pass-through cases don't double-recycle.
- Inner try/finally wraps the `HeifWriter` lifecycle so `close()` runs even if `start`, `addBitmap`, or `stop(5000)` throws.

## Safety check

Recycling the `bitmap` parameter is safe here — verified both `compress(...)` overloads in this same file are its only allocators (via `BitmapFactory.decodeByteArray` / `decodeFile`) and pass it as the terminal statement to `convertToHeif`. No caller uses it afterward.

## Test plan
- [x] Identity guards match #382's proven pattern.
- [x] `handleByteArray` / `handleFile` (their round-5 tmp-file try/finally) not touched.
- [x] No new imports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)