### PR TITLE
fix(Android): recycle source bitmap in CommonHandler JPEG/PNG/WebP path (#77 #80 #136 partial)

### DIFF
--- a/packages/flutter_image_compress_common/android/src/main/kotlin/com/fluttercandies/flutter_image_compress/handle/common/CommonHandler.kt
+++ b/packages/flutter_image_compress_common/android/src/main/kotlin/com/fluttercandies/flutter_image_compress/handle/common/CommonHandler.kt
@@ -68,21 +68,32 @@ class CommonHandler(override val type: Int) : FormatHandler {
         }
         val bitmap = BitmapFactory.decodeByteArray(arr, 0, arr.count(), options)
         val outputStream = ByteArrayOutputStream()
-        val w = bitmap.width.toFloat()
-        val h = bitmap.height.toFloat()
-        log("src width = $w")
-        log("src height = $h")
-        val scale = bitmap.calcScale(minWidth, minHeight)
-        log("scale = $scale")
-        val destW = w / scale
-        val destH = h / scale
-        log("dst width = $destW")
-        log("dst height = $destH")
-        Bitmap.createScaledBitmap(
-            bitmap, destW.toInt(),
-            destH.toInt(),
-            true
-        ).rotate(rotate).compress(bitmapFormat, quality, outputStream)
+        try {
+            val w = bitmap.width.toFloat()
+            val h = bitmap.height.toFloat()
+            log("src width = $w")
+            log("src height = $h")
+            val scale = bitmap.calcScale(minWidth, minHeight)
+            log("scale = $scale")
+            val destW = w / scale
+            val destH = h / scale
+            log("dst width = $destW")
+            log("dst height = $destH")
+            val scaled = Bitmap.createScaledBitmap(
+                bitmap, destW.toInt(),
+                destH.toInt(),
+                true
+            )
+            val rotated = scaled.rotate(rotate)
+            try {
+                rotated.compress(bitmapFormat, quality, outputStream)
+            } finally {
+                if (rotated !== scaled) rotated.recycle()
+                if (scaled !== bitmap) scaled.recycle()
+            }
+        } finally {
+            bitmap.recycle()
+        }
         return outputStream.toByteArray()
     }
 
@@ -110,7 +121,11 @@ class CommonHandler(override val type: Int) : FormatHandler {
                 options.inDither = true
             }
             val bitmap = BitmapFactory.decodeFile(path, options)
-            val array = bitmap.compress(minWidth, minHeight, quality, rotate, type)
+            val array = try {
+                bitmap.compress(minWidth, minHeight, quality, rotate, type)
+            } finally {
+                bitmap.recycle()
+            }
             if (keepExif && bitmapFormat == Bitmap.CompressFormat.JPEG) {
                 val byteArrayOutputStream = ByteArrayOutputStream()
                 byteArrayOutputStream.write(array)


### PR DESCRIPTION
## Summary
- Completes the Android bitmap-leak sweep. #382 covered the shared `BitmapCompressExt` intermediates; #387 covered the HEIC branch. This is the last remaining leak site.
- Two sites in `CommonHandler`:
  - `compress(...)` (byte-array path): decoded a source `Bitmap` via `BitmapFactory.decodeByteArray` and never recycled it. Also scaled + rotated inline via `createScaledBitmap.rotate()` (bypassing the `BitmapCompressExt` helper), so both intermediates leaked too.
  - `handleFile`: decoded a source `Bitmap` via `BitmapFactory.decodeFile` and handed it to `BitmapCompressExt.compress`, which by contract leaves the caller's `this` alone — so the source leaked.

## Fix
- Both sites wrap the encode in try/finally that recycles the source bitmap.
- The byte-array path additionally uses named `scaled` / `rotated` locals with `!==` identity guards (same pattern as #382 / #387), so intermediates are recycled even when the fluent chain short-circuits (dest dims equal to src, or `rotate == 0`).
- The `OutOfMemoryError` retry in `handleFile` is preserved — the new finally runs before the exception bubbles to the outer `catch`, so the OOM recovery path stays leak-free.

## Test plan
- [x] Identity guards match #382 / #387's proven pattern.
- [x] No changes to `BitmapCompressExt.kt` or `HeifHandler.kt` (already fixed).
- [x] No new imports; OOM retry logic untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)