### PR TITLE
fix(iOS): mkdir target parent before writeToURL (analog of #375)

### DIFF
--- a/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/CompressFileHandler.m
+++ b/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/CompressFileHandler.m
@@ -146,7 +146,23 @@
         result(nil);
         return;
     }
-    BOOL success = [data writeToURL:[[NSURL alloc] initFileURLWithPath:targetPath] atomically:YES];
+    NSURL *targetURL = [[NSURL alloc] initFileURLWithPath:targetPath];
+    NSURL *parentURL = [targetURL URLByDeletingLastPathComponent];
+    if (parentURL) {
+        NSError *dirErr = nil;
+        // Create the parent directory if missing. If it already exists,
+        // withIntermediateDirectories:YES makes this a no-op. If it fails
+        // (permission denied, path is a file, etc.), we log and continue —
+        // writeToURL: below will report the actual failure back to Dart.
+        [[NSFileManager defaultManager] createDirectoryAtURL:parentURL
+                                 withIntermediateDirectories:YES
+                                                  attributes:nil
+                                                       error:&dirErr];
+        if (dirErr != nil && [ImageCompressPlugin showLog]) {
+            NSLog(@"Failed to create target parent directory %@: %@", parentURL.path, dirErr.localizedDescription);
+        }
+    }
+    BOOL success = [data writeToURL:targetURL atomically:YES];
     result(success ? targetPath : nil);
 }
 


### PR DESCRIPTION
## Summary
- iOS analog of the Android side that shipped in #375.
- `handleCompressFileToFile:` writes to `targetPath` via `[data writeToURL:targetURL atomically:YES]`, which returns `NO` silently when the target's parent directory doesn't exist. Callers with a path like `<cachesDir>/image_compress/foo.jpg` got a clean-looking `result(nil)` with no hint of the real cause.
- Before the write, best-effort `NSFileManager createDirectoryAtURL:withIntermediateDirectories:YES`. No-op when the parent already exists; on genuine failure (permission denied, path is a file, etc.) we log behind `[ImageCompressPlugin showLog]` and let the subsequent `writeToURL:` surface the real error via `result(success ? targetPath : nil)`.

## Test plan
- [x] Only `handleCompressFileToFile:` touched — `handleMethodCall:` (byte-return) writes no file and is untouched.
- [x] `keepExif` / SYMetadata block above the write is untouched.
- [x] Placement is after the `if (data == nil)` guard so we don't create a directory for a doomed write.
- [x] Happy-path (parent exists) is a documented no-op via `withIntermediateDirectories:YES`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)