### PR TITLE
feat(Android): opt into Flutter's built-in Kotlin (KGP migration)

### DIFF
--- a/packages/flutter_image_compress_common/android/build.gradle
+++ b/packages/flutter_image_compress_common/android/build.gradle
@@ -1,15 +1,21 @@
 group 'com.fluttercandies.flutter_image_compress'
 version '1.0-SNAPSHOT'
 
-buildscript {
-    ext.kotlin_version = '1.8.20'
-    repositories {
-        google()
-        mavenCentral()
-    }
+def builtInKotlinFlag = (project.findProperty("android.builtInKotlin") ?: "false").toString().toBoolean()
+def hasKotlinExtension = project.extensions.findByName("kotlin") != null
+def useBuiltInKotlin = builtInKotlinFlag && hasKotlinExtension
 
-    dependencies {
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+if (!useBuiltInKotlin) {
+    buildscript {
+        ext.kotlin_version = '1.8.20'
+        repositories {
+            google()
+            mavenCentral()
+        }
+
+        dependencies {
+            classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        }
     }
 }
 
@@ -21,7 +27,10 @@ rootProject.allprojects {
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
+
+if (!useBuiltInKotlin) {
+    apply plugin: 'kotlin-android'
+}
 
 android {
     if (project.android.hasProperty("namespace")) {
@@ -39,14 +48,15 @@ android {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
-    kotlinOptions {
-        jvmTarget = '11'
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 
-    compileOptions {
-        // Sets Java compatibility to Java 11
-        sourceCompatibility JavaVersion.VERSION_11
-        targetCompatibility JavaVersion.VERSION_11
+    if (!useBuiltInKotlin) {
+        kotlinOptions {
+            jvmTarget = '17'
+        }
     }
 }
 
@@ -54,4 +64,12 @@ dependencies {
     implementation 'androidx.exifinterface:exifinterface:1.3.3'
     implementation 'androidx.heifwriter:heifwriter:1.0.0'
     implementation 'commons-io:commons-io:2.16.1'
+}
+
+if (useBuiltInKotlin) {
+    kotlin {
+        compilerOptions {
+            jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+        }
+    }
 }


### PR DESCRIPTION
Closes #362
Closes #361

## Summary

Migrates the Android plugin to Flutter's [built-in Kotlin integration](https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors), with a compatibility fallback so projects that still require the legacy `kotlin-android` path keep building.

- Guard the KGP classpath and `apply plugin: 'kotlin-android'` behind `android.builtInKotlin` + Kotlin-extension detection.
- Move `jvmTarget` configuration to the modern `kotlin { compilerOptions { ... } }` DSL when built-in Kotlin is active.
- Bump `sourceCompatibility` / `targetCompatibility` / `jvmTarget` from 11 to 17 to align with the example app and AGP 9 defaults.

AGP 9.0 will remove support for plugins that apply the Kotlin Gradle Plugin — this change is a prerequisite for consumers to opt into AGP 9's built-in Kotlin without losing this plugin.

Ports the approach from fluttercandies/flutter_photo_manager#1403.

## Test plan

- [x] `flutter build apk --debug` succeeds on the example app with the default legacy path (`android.builtInKotlin=false`).
- [ ] CI green.