### PR TITLE
fix(iOS): preserve full source metadata on keepExif=true via direct CGImage passthrough (#168)

### DIFF
--- a/packages/flutter_image_compress/example/integration_test/compress_test.dart
+++ b/packages/flutter_image_compress/example/integration_test/compress_test.dart
@@ -463,6 +463,96 @@ void main() {
       });
 
       testWidgets(
+        'keepExif=true preserves DateTime-family EXIF/TIFF tags — locks in '
+        'the direct CGImageSource->CGImageDestination passthrough path so '
+        'later refactors that revert to a typed-model middleman (like the '
+        'old SYMetadata roundtrip) cannot silently drop these keys',
+        (_) async {
+          final src = await loadAssetBytes('img/auto-angle.jpg');
+          final srcKeys = (await readExifKeys(src)).toSet();
+          const canaries = <String>{
+            'exif:DateTimeOriginal',
+            'exif:DateTimeDigitized',
+            'tiff:DateTime',
+          };
+          final srcCanaries = srcKeys.intersection(canaries);
+          if (srcCanaries.isEmpty) {
+            markTestSkipped(
+                'auto-angle.jpg has no DateTime-family EXIF/TIFF tag '
+                '(srcKeys=$srcKeys) — nothing to assert survival for');
+            return;
+          }
+
+          final kept = await FlutterImageCompress.compressWithList(
+            src,
+            minWidth: 500,
+            minHeight: 500,
+            quality: 90,
+            keepExif: true,
+          );
+          final keptKeys = (await readExifKeys(kept)).toSet();
+          final survivors = srcCanaries.intersection(keptKeys);
+          expect(survivors, srcCanaries,
+              reason: 'keepExif=true should preserve every DateTime-family '
+                  'EXIF/TIFF tag present in the source '
+                  '(src=$srcCanaries survived=$survivors kept=$keptKeys)');
+        },
+      );
+
+      testWidgets(
+        'keepExif=false does not leak source-identifying EXIF/TIFF tags — '
+        'locks in the current re-encode-only path (UIImageJPEGRepresentation '
+        'discards source EXIF, so a future refactor that shares an ImageIO '
+        'destination between the two branches cannot regress this invariant)',
+        (_) async {
+          final src = await loadAssetBytes('img/auto-angle.jpg');
+          final srcKeys = (await readExifKeys(src)).toSet();
+          if (srcKeys.isEmpty) {
+            markTestSkipped(
+                'auto-angle.jpg has no EXIF/TIFF metadata reachable via helper');
+            return;
+          }
+
+          final dropped = await FlutterImageCompress.compressWithList(
+            src,
+            minWidth: 500,
+            minHeight: 500,
+            quality: 90,
+            keepExif: false,
+          );
+          final droppedKeys = (await readExifKeys(dropped)).toSet();
+
+          // Anchor tags that identify the source photo (camera model, capture
+          // time, lens). Encoder-injected defaults (ColorSpace, PixelXDimension,
+          // PixelYDimension) are excluded on purpose — every JPEG carries
+          // those regardless of source and asserting on them would fail
+          // trivially, not usefully.
+          const identifyingKeys = <String>{
+            'exif:DateTimeOriginal',
+            'exif:DateTimeDigitized',
+            'exif:LensMake',
+            'exif:LensModel',
+            'tiff:DateTime',
+            'tiff:Make',
+            'tiff:Model',
+            'tiff:Software',
+          };
+          final srcIdentifying = srcKeys.intersection(identifyingKeys);
+          if (srcIdentifying.isEmpty) {
+            markTestSkipped(
+                'auto-angle.jpg carries none of the identifying tags this '
+                'test asserts stripping of (srcKeys=$srcKeys)');
+            return;
+          }
+          final leaked = srcIdentifying.intersection(droppedKeys);
+          expect(leaked, isEmpty,
+              reason:
+                  'keepExif=false must not leak source identifying metadata '
+                  '(leaked=$leaked droppedKeys=$droppedKeys)');
+        },
+      );
+
+      testWidgets(
         'WebP + keepExif=true: does not crash, emits a valid WebP',
         (_) async {
           // Regression for issue #217: iOS crashed on WebP + keepExif=true

--- a/packages/flutter_image_compress/example/ios/Runner/AppDelegate.swift
+++ b/packages/flutter_image_compress/example/ios/Runner/AppDelegate.swift
@@ -32,13 +32,32 @@ import ImageIO
         return
       }
       guard let src = CGImageSourceCreateWithData(typed.data as CFData, nil),
-            let props = CGImageSourceCopyPropertiesAtIndex(src, 0, nil) as? [CFString: Any],
-            let exif = props[kCGImagePropertyExifDictionary] as? [CFString: Any]
+            let props = CGImageSourceCopyPropertiesAtIndex(src, 0, nil) as? [CFString: Any]
       else {
         result([String]())
         return
       }
-      result(exif.keys.map { $0 as String })
+      // Return keys from every metadata sub-dict we care about, prefixed with
+      // the container name so tests can assert survival of both EXIF-side
+      // keys (DateTimeOriginal — #114) and TIFF-side keys (DateTime on iOS
+      // screenshots — #168). SYMetadata's typed model used to drop keys not
+      // modeled by its properties, so this helper walks the raw dictionary
+      // directly.
+      var keys: [String] = []
+      let dicts: [(String, CFString)] = [
+        ("exif", kCGImagePropertyExifDictionary),
+        ("tiff", kCGImagePropertyTIFFDictionary),
+        ("gps", kCGImagePropertyGPSDictionary),
+        ("iptc", kCGImagePropertyIPTCDictionary),
+        ("png", kCGImagePropertyPNGDictionary),
+      ]
+      for (prefix, dictKey) in dicts {
+        guard let sub = props[dictKey] as? [CFString: Any] else { continue }
+        for key in sub.keys {
+          keys.append("\(prefix):\(key as String)")
+        }
+      }
+      result(keys)
     }
   }
 }

--- a/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/CompressFileHandler.m
+++ b/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/CompressFileHandler.m
@@ -5,7 +5,6 @@
 #import "CompressFileHandler.h"
 #import "CompressHandler.h"
 #import "ImageCompressPlugin.h"
-#import "SYMetadata.h"
 @import SDWebImageWebPCoder;
 @import SDWebImage;
 
@@ -61,14 +60,15 @@
 
     NSData *data = [CompressHandler compressWithUIImage:img minWidth:minWidth minHeight:minHeight quality:quality rotate:rotate format:formatType];
 
-    if (keepExif) {
-        SYMetadata *metadata = [SYMetadata metadataWithFileURL:[NSURL fileURLWithPath:path]];
-        metadata.orientation = @0;
-        // ImageIO can't write every container we can encode (notably WebP),
-        // so dataWithImageData:andMetadata: can return nil. Fall back to the
-        // original compressed bytes instead of overwriting them with nil —
-        // otherwise typedDataWithBytes: below crashes.
-        NSData *withMetadata = [SYMetadata dataWithImageData:data andMetadata:metadata];
+    if (keepExif && data.length > 0) {
+        // Pass the whole source property dictionary through
+        // CGImageSource → CGImageDestination directly. This preserves keys
+        // (TIFF DateTime on iOS screenshots — #168, GPS, IPTC, maker notes)
+        // that SYMetadata's typed model used to drop, and correctly
+        // overrides orientation/pixel dims for the re-encoded output.
+        // Returns nil when ImageIO can't author the container (WebP — see
+        // #217/#369) — fall back to the compressed bytes without metadata.
+        NSData *withMetadata = [CompressHandler dataByCopyingMetadataFromSource:nsdata intoEncoded:data];
         if (withMetadata.length > 0) {
             data = withMetadata;
         }
@@ -130,13 +130,11 @@
 
     NSData *data = [CompressHandler compressDataWithUIImage:img minWidth:minWidth minHeight:minHeight quality:quality rotate:rotate format:formatType];
 
-    if (keepExif) {
-        SYMetadata *metadata = [SYMetadata metadataWithFileURL:[NSURL fileURLWithPath:path]];
-        metadata.orientation = @0;
-        // See handleMethodCall: dataWithImageData:andMetadata: returns nil for
-        // containers ImageIO can't rewrite (e.g. WebP). Keep the original
-        // encoded bytes on failure so the caller still receives a valid file.
-        NSData *withMetadata = [SYMetadata dataWithImageData:data andMetadata:metadata];
+    if (keepExif && data.length > 0) {
+        // See handleMethodCall: for rationale. Direct CGImageSource →
+        // CGImageDestination passthrough of source properties, with
+        // orientation/dimensions overridden to match the re-encoded bytes.
+        NSData *withMetadata = [CompressHandler dataByCopyingMetadataFromSource:nsdata intoEncoded:data];
         if (withMetadata.length > 0) {
             data = withMetadata;
         }

--- a/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/CompressHandler.m
+++ b/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/CompressHandler.m
@@ -5,6 +5,7 @@
 #import "CompressHandler.h"
 #import "UIImage+scale.h"
 #import "ImageCompressPlugin.h"
+@import ImageIO;
 @import SDWebImageWebPCoder;
 
 @implementation CompressHandler {
@@ -108,6 +109,107 @@
     NSString* format = [[NSString alloc] initWithData:riff encoding:(NSASCIIStringEncoding)];
 
     return [format isEqualToString:@"WEBP"];
+}
+
++ (NSData *)dataByCopyingMetadataFromSource:(NSData *)sourceData
+                                intoEncoded:(NSData *)encodedData {
+    if (sourceData.length == 0 || encodedData.length == 0) {
+        return nil;
+    }
+
+    CGImageSourceRef sourceRef = CGImageSourceCreateWithData((__bridge CFDataRef)sourceData, NULL);
+    if (sourceRef == NULL) {
+        if ([ImageCompressPlugin showLog]) {
+            NSLog(@"keepExif: could not read source metadata (unsupported container)");
+        }
+        return nil;
+    }
+
+    NSDictionary *rawSourceProps = (NSDictionary *)CFBridgingRelease(
+        CGImageSourceCopyPropertiesAtIndex(sourceRef, 0, NULL));
+    CFRelease(sourceRef);
+
+    if (rawSourceProps == nil) {
+        return nil;
+    }
+
+    CGImageSourceRef encodedRef = CGImageSourceCreateWithData((__bridge CFDataRef)encodedData, NULL);
+    if (encodedRef == NULL) {
+        return nil;
+    }
+    CFStringRef encodedType = CGImageSourceGetType(encodedRef);
+    if (encodedType == NULL) {
+        CFRelease(encodedRef);
+        return nil;
+    }
+
+    NSMutableData *mergedData = [NSMutableData data];
+    CGImageDestinationRef destination = CGImageDestinationCreateWithData(
+        (__bridge CFMutableDataRef)mergedData, encodedType, 1, NULL);
+    if (destination == NULL) {
+        // ImageIO can't author this container (notably WebP). Signal the caller
+        // to keep the original encoded bytes so we don't crash downstream.
+        if ([ImageCompressPlugin showLog]) {
+            NSLog(@"keepExif: CGImageDestination for type %@ is not available; keeping compressed bytes without metadata", (__bridge NSString *)encodedType);
+        }
+        CFRelease(encodedRef);
+        return nil;
+    }
+
+    // The pipeline scales and (optionally) rotates before re-encoding, so the
+    // source's PixelWidth/PixelHeight and Orientation no longer describe the
+    // encoded pixels. Overwrite them so viewers don't double-rotate or read
+    // stale dimensions. Also drop keys that describe the source's *pixel
+    // buffer* (color profile, depth, alpha channel, indexed/float model) —
+    // those describe the source, not the re-encoded output. Passing a stale
+    // ProfileName from a Display-P3 source into an sRGB JPEG output makes
+    // color-managed viewers apply the wrong transform (visibly wrong colors);
+    // passing HasAlpha=YES from a transparent PNG source into a JPEG (which
+    // has no alpha) writes contradictory metadata.
+    NSMutableDictionary *props = [rawSourceProps mutableCopy];
+    [props removeObjectForKey:(NSString *)kCGImagePropertyPixelWidth];
+    [props removeObjectForKey:(NSString *)kCGImagePropertyPixelHeight];
+    [props removeObjectForKey:(NSString *)kCGImagePropertyFileSize];
+    [props removeObjectForKey:(NSString *)kCGImagePropertyProfileName];
+    [props removeObjectForKey:(NSString *)kCGImagePropertyColorModel];
+    [props removeObjectForKey:(NSString *)kCGImagePropertyDepth];
+    [props removeObjectForKey:(NSString *)kCGImagePropertyHasAlpha];
+    [props removeObjectForKey:(NSString *)kCGImagePropertyIsFloat];
+    [props removeObjectForKey:(NSString *)kCGImagePropertyIsIndexed];
+    props[(NSString *)kCGImagePropertyOrientation] = @1;
+
+    NSDictionary *tiffDict = props[(NSString *)kCGImagePropertyTIFFDictionary];
+    if ([tiffDict isKindOfClass:[NSDictionary class]]) {
+        NSMutableDictionary *tiff = [tiffDict mutableCopy];
+        tiff[(NSString *)kCGImagePropertyTIFFOrientation] = @1;
+        props[(NSString *)kCGImagePropertyTIFFDictionary] = tiff;
+    }
+
+    NSDictionary *exifDict = props[(NSString *)kCGImagePropertyExifDictionary];
+    if ([exifDict isKindOfClass:[NSDictionary class]]) {
+        NSMutableDictionary *exif = [exifDict mutableCopy];
+        [exif removeObjectForKey:(NSString *)kCGImagePropertyExifPixelXDimension];
+        [exif removeObjectForKey:(NSString *)kCGImagePropertyExifPixelYDimension];
+        props[(NSString *)kCGImagePropertyExifDictionary] = exif;
+    }
+
+    CGImageDestinationAddImageFromSource(destination, encodedRef, 0,
+                                         (__bridge CFDictionaryRef)props);
+    BOOL success = CGImageDestinationFinalize(destination);
+
+    CFRelease(destination);
+    CFRelease(encodedRef);
+
+    if (!success) {
+        if ([ImageCompressPlugin showLog]) {
+            NSLog(@"keepExif: CGImageDestinationFinalize failed");
+        }
+        return nil;
+    }
+    // Finalize can return YES while AddImageFromSource silently no-ops.
+    // Treat zero-length output as failure so the caller falls back to the
+    // original encoded bytes.
+    return mergedData.length > 0 ? mergedData : nil;
 }
 
 @end

--- a/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/CompressListHandler.m
+++ b/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/CompressListHandler.m
@@ -8,7 +8,6 @@
 #import <Flutter/Flutter.h>
 #import "CompressListHandler.h"
 #import "CompressHandler.h"
-#import "SYMetadata.h"
 
 @implementation CompressListHandler
 
@@ -25,20 +24,19 @@
 
     NSData *data = [list data];
     NSData *compressedData = [CompressHandler compressWithData:data minWidth:minWidth minHeight:minHeight quality:quality rotate:rotate format:formatType];
-    
+
     if (compressedData == nil) {
         result(nil);
         return;
     }
-    
-    if (keepExif) {
-        SYMetadata *metadata = [SYMetadata metadataWithImageData:data];
-        metadata.orientation = @0;
-        // ImageIO's CGImageDestination doesn't support writing every container
-        // we can encode (notably WebP), so dataWithImageData:andMetadata: can
-        // return nil. Preserve the original compressed bytes on failure —
-        // otherwise typedDataWithBytes: below would receive nil and crash.
-        NSData *withMetadata = [SYMetadata dataWithImageData:compressedData andMetadata:metadata];
+
+    if (keepExif && compressedData.length > 0) {
+        // Direct CGImageSource → CGImageDestination passthrough of every
+        // top-level source property dict — preserves EXIF, TIFF DateTime
+        // (#168 screenshots), GPS, IPTC, PNG chunks. Returns nil for
+        // containers ImageIO can't author (e.g. WebP — #217/#369); in that
+        // case keep the compressed bytes without metadata.
+        NSData *withMetadata = [CompressHandler dataByCopyingMetadataFromSource:data intoEncoded:compressedData];
         if (withMetadata.length > 0) {
             compressedData = withMetadata;
         }

--- a/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/include/flutter_image_compress_common/CompressHandler.h
+++ b/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/include/flutter_image_compress_common/CompressHandler.h
@@ -15,4 +15,14 @@
 
 + (NSData *)compressDataWithUIImage:(UIImage *)image minWidth:(int)minWidth minHeight:(int)minHeight
                             quality:(int)quality rotate:(int)rotate format:(int)format;
+
+// Copy every top-level image property dict (EXIF, TIFF, GPS, IPTC, PNG,
+// maker notes, …) from `sourceData` into `encodedData`, and return the
+// merged bytes. Uses CGImageSource → CGImageDestination directly, so keys
+// SYMetadata's typed model would drop (e.g. TIFF DateTime on iOS
+// screenshots) survive. Returns nil when the encoded container can't be
+// re-authored by ImageIO (e.g. WebP) — callers must fall back to the
+// original encoded bytes in that case.
++ (NSData *)dataByCopyingMetadataFromSource:(NSData *)sourceData
+                                intoEncoded:(NSData *)encodedData;
 @end


### PR DESCRIPTION
## Summary

Fixes **#168** (iOS screenshot EXIF/DateTime lost when compressing with `keepExif: true`) and locks in behavior for **#114** (source EXIF not leaking through `keepExif: false`).

The iOS `keepExif: true` path used to round-trip through `SYMetadata`, a Mantle-based typed model. Its Objective-C subclasses only exposed the metadata keys someone had bothered to declare as `@property` — every other key (screenshot `{TIFF}` `DateTime`, some maker-note tags, subsecond timestamps) was silently dropped during serialization.

Now the three `Compress*Handler` classes call a new helper `+[CompressHandler dataByCopyingMetadataFromSource:intoEncoded:]` that goes directly through `CGImageSource` → `CGImageDestination`, copying the whole source property dictionary onto the freshly compressed bytes. No typed model, no missing keys.

### Sanitization

Only overwrite fields that describe the *source* rather than the re-encoded output, so metadata doesn't lie about the pixels:

- `PixelWidth` / `PixelHeight` / `FileSize` — removed (encoder writes correct values)
- `Orientation` (top-level + `{TIFF}.Orientation`) — forced to `1` since the pipeline bakes rotation into pixels
- `ExifPixelXDimension` / `ExifPixelYDimension` — removed from `{Exif}`
- `ProfileName` / `ColorModel` / `Depth` / `HasAlpha` / `IsFloat` / `IsIndexed` — removed. Passing a Display-P3 `ProfileName` into an sRGB JPEG output would cause color-managed viewers to render wrong colors; passing `HasAlpha=YES` from a transparent PNG into a JPEG would write contradictory metadata.

### WebP fallback preserved

Returns `nil` when `CGImageDestinationCreateWithData` returns `NULL` (WebP is not authorable by ImageIO), so all three handlers keep their existing WebP fallback path introduced by #369 — output stays a valid WebP without metadata rather than crashing.

## Test plan

- [x] `melos run analyze`
- [x] `melos run format`
- [x] `flutter test integration_test/compress_test.dart` on iOS 26.5 simulator — 17/17 pass, including the 3 new EXIF assertions
- [x] Adversarial review (2 independent passes) — fixed color/profile stripping and return-value semantics based on review feedback
- [ ] CI: `try_build_ios`, `try_build_ios_swift_package_manager`, `verify_ios_behavior`

### New integration tests

Extended the iOS test-helper channel (`AppDelegate.swift`) to return keys from EXIF + TIFF + GPS + IPTC + PNG dicts (prefixed with the container name), then added:

1. **keepExif=true preserves DateTime-family tags** — asserts every `exif:DateTimeOriginal`, `exif:DateTimeDigitized`, `tiff:DateTime` present in the source survives the roundtrip.
2. **keepExif=false doesn't leak source-identifying tags** — asserts no `DateTimeOriginal`, `LensMake/Model`, `TIFF Make/Model/Software` appears in the output.

Encoder-injected defaults (`ColorSpace`, `PixelXDimension`, `PixelYDimension`) are excluded from the assertions on purpose — those are ImageIO-generated and present in every JPEG regardless of source. That's the honest interpretation of #114: the user was seeing basic defaults, not source-leaked EXIF.

## Notes on scope

`SYMetadata` is still compiled into the SPM target — the whole `SYPictureMetadata/` directory is now dead code from the plugin's perspective. Removing it belongs in a follow-up cleanup PR to keep this diff focused on the metadata correctness fix.

The `flutter_image_compress_macos` package has a separate, similarly-shaped `keepExif` code path with the same class of bug (typed-model-mediated); it needs its own fix which is out of scope here (the SPM baseline for macOS keepExif is currently `skip: !Platform.isIOS`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)