### PR TITLE
chore(example): dedup iOS/macOS test-only ExifTestHelper into one shared Swift file

### DIFF
--- a/packages/flutter_image_compress/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/flutter_image_compress/example/ios/Runner.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		331C808B294A63AB00263BE5 /* RunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C807B294A618700263BE5 /* RunnerTests.swift */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
+		E017C0DE00000000000000A1 /* ExifTestHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E017C0DE00000000000000A2 /* ExifTestHelper.swift */; };
 		7884E8682EC3CC0700C636F2 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7884E8672EC3CC0400C636F2 /* SceneDelegate.swift */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
@@ -48,6 +49,7 @@
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		E017C0DE00000000000000A2 /* ExifTestHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ExifTestHelper.swift; path = "../shared/ExifTestHelper.swift"; sourceTree = SOURCE_ROOT; };
 		7884E8672EC3CC0400C636F2 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
@@ -118,6 +120,7 @@
 				1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */,
 				1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */,
 				74858FAE1ED2DC5600515810 /* AppDelegate.swift */,
+				E017C0DE00000000000000A2 /* ExifTestHelper.swift */,
 				7884E8672EC3CC0400C636F2 /* SceneDelegate.swift */,
 				74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */,
 			);
@@ -272,6 +275,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */,
+				E017C0DE00000000000000A1 /* ExifTestHelper.swift in Sources */,
 				1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */,
 				7884E8682EC3CC0700C636F2 /* SceneDelegate.swift in Sources */,
 			);

--- a/packages/flutter_image_compress/example/ios/Runner/AppDelegate.swift
+++ b/packages/flutter_image_compress/example/ios/Runner/AppDelegate.swift
@@ -1,6 +1,5 @@
 import Flutter
 import UIKit
-import ImageIO
 
 @main
 @objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
@@ -13,51 +12,9 @@ import ImageIO
 
   func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {
     GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
-    Self.registerTestHelperChannel(registry: engineBridge.pluginRegistry)
-  }
-
-  private static func registerTestHelperChannel(registry: FlutterPluginRegistry) {
-    guard let registrar = registry.registrar(forPlugin: "TestHelper") else { return }
-    let channel = FlutterMethodChannel(
-      name: "flutter_image_compress/test",
-      binaryMessenger: registrar.messenger()
-    )
-    channel.setMethodCallHandler { call, result in
-      guard call.method == "readExifKeys" else {
-        result(FlutterMethodNotImplemented)
-        return
-      }
-      guard let typed = call.arguments as? FlutterStandardTypedData else {
-        result([String]())
-        return
-      }
-      guard let src = CGImageSourceCreateWithData(typed.data as CFData, nil),
-            let props = CGImageSourceCopyPropertiesAtIndex(src, 0, nil) as? [CFString: Any]
-      else {
-        result([String]())
-        return
-      }
-      // Return keys from every metadata sub-dict we care about, prefixed with
-      // the container name so tests can assert survival of both EXIF-side
-      // keys (DateTimeOriginal — #114) and TIFF-side keys (DateTime on iOS
-      // screenshots — #168). SYMetadata's typed model used to drop keys not
-      // modeled by its properties, so this helper walks the raw dictionary
-      // directly.
-      var keys: [String] = []
-      let dicts: [(String, CFString)] = [
-        ("exif", kCGImagePropertyExifDictionary),
-        ("tiff", kCGImagePropertyTIFFDictionary),
-        ("gps", kCGImagePropertyGPSDictionary),
-        ("iptc", kCGImagePropertyIPTCDictionary),
-        ("png", kCGImagePropertyPNGDictionary),
-      ]
-      for (prefix, dictKey) in dicts {
-        guard let sub = props[dictKey] as? [CFString: Any] else { continue }
-        for key in sub.keys {
-          keys.append("\(prefix):\(key as String)")
-        }
-      }
-      result(keys)
-    }
+    // Test-only helper channel implementation lives at ../../shared/
+    // and is added to both Runner projects via a relative file reference.
+    guard let registrar = engineBridge.pluginRegistry.registrar(forPlugin: "TestHelper") else { return }
+    ExifTestHelper.register(with: registrar.messenger())
   }
 }

--- a/packages/flutter_image_compress/example/macos/Runner.xcodeproj/project.pbxproj
+++ b/packages/flutter_image_compress/example/macos/Runner.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		33CC10F32044A3C60003C045 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F22044A3C60003C045 /* Assets.xcassets */; };
 		33CC10F62044A3C60003C045 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F42044A3C60003C045 /* MainMenu.xib */; };
 		33CC11132044BFA00003C045 /* MainFlutterWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CC11122044BFA00003C045 /* MainFlutterWindow.swift */; };
+		E017C0DE00000000000000A3 /* ExifTestHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E017C0DE00000000000000A4 /* ExifTestHelper.swift */; };
 		EC2565D6004999E860783EDB /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 949414A3CA7EEB7EBBE3C503 /* Pods_Runner.framework */; };
 /* End PBXBuildFile section */
 
@@ -72,6 +73,7 @@
 		33CC10F52044A3C60003C045 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/MainMenu.xib; sourceTree = "<group>"; };
 		33CC10F72044A3C60003C045 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = Runner/Info.plist; sourceTree = "<group>"; };
 		33CC11122044BFA00003C045 /* MainFlutterWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainFlutterWindow.swift; sourceTree = "<group>"; };
+		E017C0DE00000000000000A4 /* ExifTestHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ExifTestHelper.swift; path = "../shared/ExifTestHelper.swift"; sourceTree = SOURCE_ROOT; };
 		33CEB47222A05771004F2AC0 /* Flutter-Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Flutter-Debug.xcconfig"; sourceTree = "<group>"; };
 		33CEB47422A05771004F2AC0 /* Flutter-Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Flutter-Release.xcconfig"; sourceTree = "<group>"; };
 		33CEB47722A0578A004F2AC0 /* Flutter-Generated.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = "Flutter-Generated.xcconfig"; path = "ephemeral/Flutter-Generated.xcconfig"; sourceTree = "<group>"; };
@@ -191,6 +193,7 @@
 			children = (
 				33CC10F02044A3C60003C045 /* AppDelegate.swift */,
 				33CC11122044BFA00003C045 /* MainFlutterWindow.swift */,
+				E017C0DE00000000000000A4 /* ExifTestHelper.swift */,
 				33E51913231747F40026EE4D /* DebugProfile.entitlements */,
 				33E51914231749380026EE4D /* Release.entitlements */,
 				33CC11242044D66E0003C045 /* Resources */,
@@ -438,6 +441,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				33CC11132044BFA00003C045 /* MainFlutterWindow.swift in Sources */,
+				E017C0DE00000000000000A3 /* ExifTestHelper.swift in Sources */,
 				33CC10F12044A3C60003C045 /* AppDelegate.swift in Sources */,
 				335BBD1B22A9A15E00E9071D /* GeneratedPluginRegistrant.swift in Sources */,
 			);

--- a/packages/flutter_image_compress/example/macos/Runner/MainFlutterWindow.swift
+++ b/packages/flutter_image_compress/example/macos/Runner/MainFlutterWindow.swift
@@ -1,6 +1,5 @@
 import Cocoa
 import FlutterMacOS
-import ImageIO
 
 class MainFlutterWindow: NSWindow {
   override func awakeFromNib() {
@@ -10,50 +9,10 @@ class MainFlutterWindow: NSWindow {
     self.setFrame(windowFrame, display: true)
 
     RegisterGeneratedPlugins(registry: flutterViewController)
-    Self.registerTestHelperChannel(controller: flutterViewController)
+    // Test-only helper channel implementation lives at ../../shared/ and is
+    // added to both Runner projects via a relative file reference.
+    ExifTestHelper.register(with: flutterViewController.engine.binaryMessenger)
 
     super.awakeFromNib()
-  }
-
-  private static func registerTestHelperChannel(controller: FlutterViewController) {
-    let channel = FlutterMethodChannel(
-      name: "flutter_image_compress/test",
-      binaryMessenger: controller.engine.binaryMessenger
-    )
-    channel.setMethodCallHandler { call, result in
-      guard call.method == "readExifKeys" else {
-        result(FlutterMethodNotImplemented)
-        return
-      }
-      guard let typed = call.arguments as? FlutterStandardTypedData else {
-        result([String]())
-        return
-      }
-      guard let src = CGImageSourceCreateWithData(typed.data as CFData, nil),
-            let props = CGImageSourceCopyPropertiesAtIndex(src, 0, nil) as? [CFString: Any]
-      else {
-        result([String]())
-        return
-      }
-      // Same shape as the iOS helper: keys from every metadata sub-dict we
-      // care about, prefixed with the container name so tests can assert
-      // survival of both EXIF-side keys (DateTimeOriginal) and TIFF-side
-      // keys (DateTime on iOS screenshots).
-      var keys: [String] = []
-      let dicts: [(String, CFString)] = [
-        ("exif", kCGImagePropertyExifDictionary),
-        ("tiff", kCGImagePropertyTIFFDictionary),
-        ("gps", kCGImagePropertyGPSDictionary),
-        ("iptc", kCGImagePropertyIPTCDictionary),
-        ("png", kCGImagePropertyPNGDictionary),
-      ]
-      for (prefix, dictKey) in dicts {
-        guard let sub = props[dictKey] as? [CFString: Any] else { continue }
-        for key in sub.keys {
-          keys.append("\(prefix):\(key as String)")
-        }
-      }
-      result(keys)
-    }
   }
 }

--- a/packages/flutter_image_compress/example/shared/ExifTestHelper.swift
+++ b/packages/flutter_image_compress/example/shared/ExifTestHelper.swift
@@ -1,0 +1,74 @@
+// Shared test-only helper channel for iOS + macOS example Runners.
+//
+// The plugin's public MethodChannel intentionally does not expose an EXIF
+// reader — that would be a new API surface unrelated to compression. But
+// the integration tests still need to verify what metadata the plugin's
+// output actually contains. This file registers a private-to-example
+// channel (`flutter_image_compress/test`) that walks the CGImageSource
+// property tree for the passed-in bytes.
+//
+// Both `example/ios/Runner/AppDelegate.swift` and
+// `example/macos/Runner/MainFlutterWindow.swift` reference this single
+// file (via a relative Xcode file reference), so the reader logic lives
+// in exactly one place regardless of platform. ImageIO is a Darwin
+// framework available on both iOS and macOS, so the implementation is
+// identical modulo the FlutterBinaryMessenger type on either side.
+
+import Foundation
+import ImageIO
+#if canImport(Flutter)
+  import Flutter
+#elseif canImport(FlutterMacOS)
+  import FlutterMacOS
+#endif
+
+enum ExifTestHelper {
+  /// Register the `flutter_image_compress/test` channel on the given
+  /// binary messenger. Call from the Runner's plugin-registration site
+  /// on both iOS and macOS.
+  static func register(with messenger: FlutterBinaryMessenger) {
+    let channel = FlutterMethodChannel(
+      name: "flutter_image_compress/test",
+      binaryMessenger: messenger
+    )
+    channel.setMethodCallHandler { call, result in
+      guard call.method == "readExifKeys" else {
+        result(FlutterMethodNotImplemented)
+        return
+      }
+      guard let typed = call.arguments as? FlutterStandardTypedData else {
+        result([String]())
+        return
+      }
+      result(readExifKeys(from: typed.data))
+    }
+  }
+
+  /// Walk every EXIF/TIFF/GPS/IPTC/PNG sub-dict in the image's property
+  /// tree and return the keys prefixed with the container name. Tests
+  /// use the prefix to distinguish e.g. `exif:DateTimeOriginal` from
+  /// `tiff:DateTime` — the same key name can live in more than one
+  /// container, and both are load-bearing for keepExif regressions.
+  private static func readExifKeys(from data: Data) -> [String] {
+    guard let src = CGImageSourceCreateWithData(data as CFData, nil),
+          let props = CGImageSourceCopyPropertiesAtIndex(src, 0, nil) as? [CFString: Any]
+    else {
+      return []
+    }
+    var keys: [String] = []
+    let dicts: [(String, CFString)] = [
+      ("exif", kCGImagePropertyExifDictionary),
+      ("tiff", kCGImagePropertyTIFFDictionary),
+      ("gps", kCGImagePropertyGPSDictionary),
+      ("iptc", kCGImagePropertyIPTCDictionary),
+      ("png", kCGImagePropertyPNGDictionary),
+    ]
+    for (prefix, dictKey) in dicts {
+      guard let sub = props[dictKey] as? [CFString: Any] else { continue }
+      for key in sub.keys {
+        keys.append("\(prefix):\(key as String)")
+      }
+    }
+    return keys
+  }
+}


### PR DESCRIPTION
Follow-up to #391 / #392 — collapses the two copies of the test-only EXIF reader helper into one shared source file.

## Why

#391 added the `flutter_image_compress/test` MethodChannel handler for `readExifKeys` in `example/ios/Runner/AppDelegate.swift`. #392 added the same handler for macOS in `example/macos/Runner/MainFlutterWindow.swift`. Both use identical `CGImageSourceCopyPropertiesAtIndex` walks — the code is byte-for-byte the same modulo the `Flutter` vs `FlutterMacOS` import.

Adding a new metadata dict to inspect (or a new helper method) meant editing two files in lockstep. That's real maintenance cost for something that's inherently platform-invariant (ImageIO is a Darwin framework available identically on both).

## How

- New file `packages/flutter_image_compress/example/shared/ExifTestHelper.swift` — the whole implementation lives here, once. `#if canImport(Flutter) / FlutterMacOS` handles the framework import split without duplication.
- Both Runner Xcode projects reference the same physical file via `sourceTree = SOURCE_ROOT, path = ../shared/ExifTestHelper.swift`. No copy, no symlink — it's genuinely one file compiled into two apps.
- `AppDelegate.swift` and `MainFlutterWindow.swift` shrink to one call each: `ExifTestHelper.register(with: registrar.messenger())`.

Net diff: `+89 / -91`. Two Runner files got a lot smaller; one new shared file appeared.

## Not addressing

The bigger question raised in review — "should `readExif` be a public plugin API instead?" — is discussed and answered no in the earlier thread: this is a test-only utility, not a compression concern, so it stays out of the plugin's API surface. Deduping the test helper is the smallest change that removes the maintenance burden without polluting the public interface.

## Test plan

- [x] iOS 26.5 simulator — 18/18 pass (same as before)
- [x] macOS host — 13 pass + 5 iOS-only skipped (same as before)
- [ ] CI: iOS/macOS cocoapods + SPM; Android; Web

🤖 Generated with [Claude Code](https://claude.com/claude-code)