### PR TITLE
docs(Android): surface HEIC + keepExif limitation via Log.w + README matrix (refs #130)

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,8 +259,21 @@ If this parameter is true, EXIF information is saved in the compressed result.
 Attention should be paid to the following points:
 
 1. Default value is false.
-2. Even if set to true, the direction attribute is not included.
-3. Only support jpg format, PNG format does not support.
+2. Even if set to true, the `Orientation` tag is normalized to `1`/`ORIENTATION_NORMAL` — the pipeline bakes rotation into pixels, so preserving the source orientation tag would cause viewers to double-rotate.
+3. Support varies by output format **and** platform:
+
+   | Output format | iOS / macOS | Android |
+   | --- | --- | --- |
+   | JPEG | ✅ full sub-dict passthrough (EXIF, TIFF, GPS, IPTC, PNG) | ✅ ~90 EXIF tags via `androidx.exifinterface` |
+   | PNG  | ✅ same passthrough | ❌ dropped — see [PNG/WebP note](#png--webp-keepexif-on-android) below |
+   | WebP | ❌ ImageIO cannot author WebP metadata; output is a valid WebP without EXIF | ❌ same as PNG |
+   | HEIC | ✅ same passthrough | ❌ `androidx.exifinterface` refuses HEIF write; the resulting HEIC is valid but has no EXIF. `HeifHandler` logs a clear warning in this case. |
+
+   The rows marked ❌ still return valid image bytes — you just do not get EXIF back. `keepExif: true` never fails the whole compression call.
+
+##### PNG / WebP keepExif on Android
+
+Android's `CommonHandler` currently only invokes `ExifKeeper` when the output format is JPEG. PNG and WebP output paths drop EXIF regardless of `keepExif`. See issue [#130](https://github.com/fluttercandies/flutter_image_compress/issues/130).
 
 ## Result
 

--- a/packages/flutter_image_compress/example/android/app/build.gradle.kts
+++ b/packages/flutter_image_compress/example/android/app/build.gradle.kts
@@ -43,3 +43,11 @@ kotlin {
 flutter {
     source = "../.."
 }
+
+dependencies {
+    // Test-only helper (see MainActivity.kt) reads EXIF for integration tests.
+    // The plugin itself uses this but declares it as `implementation` scope, so
+    // the example app can't see it transitively — declare explicitly here.
+    // KEEP IN SYNC with `flutter_image_compress_common/android/build.gradle`.
+    implementation("androidx.exifinterface:exifinterface:1.3.3")
+}

--- a/packages/flutter_image_compress/example/android/app/src/main/kotlin/com/fluttercandies/imagecompressexample/MainActivity.kt
+++ b/packages/flutter_image_compress/example/android/app/src/main/kotlin/com/fluttercandies/imagecompressexample/MainActivity.kt
@@ -1,5 +1,158 @@
 package com.fluttercandies.imagecompressexample
 
+import android.util.Log
+import androidx.exifinterface.media.ExifInterface
 import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.MethodChannel
+import java.io.ByteArrayInputStream
 
-class MainActivity : FlutterActivity()
+class MainActivity : FlutterActivity() {
+    override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
+        super.configureFlutterEngine(flutterEngine)
+        // Mirrors the iOS/macOS example test helper (see example/shared/ExifTestHelper.swift).
+        // The plugin's public channel intentionally does not expose an EXIF
+        // reader; this test-only channel lets integration tests verify what
+        // metadata survives the compression pipeline on Android.
+        //
+        // Returns tags prefixed with a container name so tests can assert
+        // survival of both plain EXIF (exif:DateTimeOriginal), TIFF-side
+        // (tiff:DateTime, tiff:Make), and GPS (gps:GPSLatitude).
+        // Prefix mapping aligns with the CGImageProperty sub-dict names iOS
+        // uses so tests can share the same canary constants.
+        //
+        // The tag inventory here is intentionally broad — it mirrors every
+        // tag ExifKeeper attempts to preserve (see
+        // flutter_image_compress_common/.../exif/ExifKeeper.java). Keeping
+        // the helper's tag list narrower than the writer's would let a
+        // regression that shrinks ExifKeeper pass silently — the test would
+        // report "kept everything" simply because it wasn't looking at the
+        // dropped tag.
+        MethodChannel(
+            flutterEngine.dartExecutor.binaryMessenger,
+            "flutter_image_compress/test"
+        ).setMethodCallHandler { call, result ->
+            if (call.method != "readExifKeys") {
+                result.notImplemented()
+                return@setMethodCallHandler
+            }
+            val bytes = call.arguments as? ByteArray
+            if (bytes == null) {
+                Log.w(
+                    "ExifTestHelper",
+                    "readExifKeys called with wrong argument type: " +
+                            "${call.arguments?.javaClass?.name}"
+                )
+                result.error(
+                    "BAD_ARG",
+                    "readExifKeys expects a ByteArray; got " +
+                            (call.arguments?.javaClass?.name ?: "null"),
+                    null,
+                )
+                return@setMethodCallHandler
+            }
+            try {
+                val exif = ExifInterface(ByteArrayInputStream(bytes))
+                val out = mutableListOf<String>()
+                for (tag in ANDROID_TAG_PREFIXES) {
+                    if (exif.getAttribute(tag.name) != null) {
+                        out.add("${tag.prefix}:${tag.displayName}")
+                    }
+                }
+                result.success(out)
+            } catch (e: Exception) {
+                Log.w("ExifTestHelper", "readExifKeys failed: $e")
+                result.success(emptyList<String>())
+            }
+        }
+    }
+
+    // Prefix and displayName pair up so the output keys look like the ones
+    // iOS emits from CGImageProperty sub-dicts. The list intentionally mirrors
+    // every tag ExifKeeper.java preserves; keep them in sync so a shrinking
+    // regression on ExifKeeper stays visible to the tests.
+    private data class AndroidExifTag(
+        val name: String,
+        val prefix: String,
+        val displayName: String,
+    )
+
+    companion object {
+        private val ANDROID_TAG_PREFIXES = listOf(
+            // Descriptive / authorship (TIFF-side)
+            AndroidExifTag(ExifInterface.TAG_IMAGE_DESCRIPTION, "tiff", "ImageDescription"),
+            AndroidExifTag(ExifInterface.TAG_MAKE, "tiff", "Make"),
+            AndroidExifTag(ExifInterface.TAG_MODEL, "tiff", "Model"),
+            AndroidExifTag(ExifInterface.TAG_SOFTWARE, "tiff", "Software"),
+            AndroidExifTag(ExifInterface.TAG_ARTIST, "tiff", "Artist"),
+            AndroidExifTag(ExifInterface.TAG_COPYRIGHT, "tiff", "Copyright"),
+            AndroidExifTag(ExifInterface.TAG_USER_COMMENT, "exif", "UserComment"),
+            // Resolution
+            AndroidExifTag(ExifInterface.TAG_X_RESOLUTION, "tiff", "XResolution"),
+            AndroidExifTag(ExifInterface.TAG_Y_RESOLUTION, "tiff", "YResolution"),
+            AndroidExifTag(ExifInterface.TAG_RESOLUTION_UNIT, "tiff", "ResolutionUnit"),
+            AndroidExifTag(ExifInterface.TAG_Y_CB_CR_POSITIONING, "tiff", "YCbCrPositioning"),
+            // Date/time
+            AndroidExifTag(ExifInterface.TAG_DATETIME, "tiff", "DateTime"),
+            AndroidExifTag(ExifInterface.TAG_DATETIME_ORIGINAL, "exif", "DateTimeOriginal"),
+            AndroidExifTag(ExifInterface.TAG_DATETIME_DIGITIZED, "exif", "DateTimeDigitized"),
+            AndroidExifTag(ExifInterface.TAG_SUBSEC_TIME, "exif", "SubsecTime"),
+            AndroidExifTag(ExifInterface.TAG_SUBSEC_TIME_ORIGINAL, "exif", "SubsecTimeOriginal"),
+            AndroidExifTag(ExifInterface.TAG_SUBSEC_TIME_DIGITIZED, "exif", "SubsecTimeDigitized"),
+            AndroidExifTag(ExifInterface.TAG_OFFSET_TIME, "exif", "OffsetTime"),
+            AndroidExifTag(ExifInterface.TAG_OFFSET_TIME_ORIGINAL, "exif", "OffsetTimeOriginal"),
+            AndroidExifTag(ExifInterface.TAG_OFFSET_TIME_DIGITIZED, "exif", "OffsetTimeDigitized"),
+            // Exposure / capture parameters
+            AndroidExifTag(ExifInterface.TAG_EXPOSURE_TIME, "exif", "ExposureTime"),
+            AndroidExifTag(ExifInterface.TAG_F_NUMBER, "exif", "FNumber"),
+            AndroidExifTag(ExifInterface.TAG_EXPOSURE_PROGRAM, "exif", "ExposureProgram"),
+            AndroidExifTag(ExifInterface.TAG_ISO_SPEED_RATINGS, "exif", "ISOSpeedRatings"),
+            AndroidExifTag(ExifInterface.TAG_SHUTTER_SPEED_VALUE, "exif", "ShutterSpeedValue"),
+            AndroidExifTag(ExifInterface.TAG_APERTURE_VALUE, "exif", "ApertureValue"),
+            AndroidExifTag(ExifInterface.TAG_BRIGHTNESS_VALUE, "exif", "BrightnessValue"),
+            AndroidExifTag(ExifInterface.TAG_EXPOSURE_BIAS_VALUE, "exif", "ExposureBiasValue"),
+            AndroidExifTag(ExifInterface.TAG_MAX_APERTURE_VALUE, "exif", "MaxApertureValue"),
+            AndroidExifTag(ExifInterface.TAG_SUBJECT_DISTANCE, "exif", "SubjectDistance"),
+            AndroidExifTag(ExifInterface.TAG_METERING_MODE, "exif", "MeteringMode"),
+            AndroidExifTag(ExifInterface.TAG_LIGHT_SOURCE, "exif", "LightSource"),
+            AndroidExifTag(ExifInterface.TAG_FLASH, "exif", "Flash"),
+            AndroidExifTag(ExifInterface.TAG_FOCAL_LENGTH, "exif", "FocalLength"),
+            AndroidExifTag(ExifInterface.TAG_FLASH_ENERGY, "exif", "FlashEnergy"),
+            AndroidExifTag(ExifInterface.TAG_EXPOSURE_INDEX, "exif", "ExposureIndex"),
+            AndroidExifTag(ExifInterface.TAG_SENSITIVITY_TYPE, "exif", "SensitivityType"),
+            AndroidExifTag(ExifInterface.TAG_EXPOSURE_MODE, "exif", "ExposureMode"),
+            AndroidExifTag(ExifInterface.TAG_WHITE_BALANCE, "exif", "WhiteBalance"),
+            AndroidExifTag(ExifInterface.TAG_DIGITAL_ZOOM_RATIO, "exif", "DigitalZoomRatio"),
+            AndroidExifTag(ExifInterface.TAG_FOCAL_LENGTH_IN_35MM_FILM, "exif", "FocalLengthIn35mmFilm"),
+            AndroidExifTag(ExifInterface.TAG_SCENE_CAPTURE_TYPE, "exif", "SceneCaptureType"),
+            AndroidExifTag(ExifInterface.TAG_GAIN_CONTROL, "exif", "GainControl"),
+            AndroidExifTag(ExifInterface.TAG_CONTRAST, "exif", "Contrast"),
+            AndroidExifTag(ExifInterface.TAG_SATURATION, "exif", "Saturation"),
+            AndroidExifTag(ExifInterface.TAG_SHARPNESS, "exif", "Sharpness"),
+            AndroidExifTag(ExifInterface.TAG_SUBJECT_DISTANCE_RANGE, "exif", "SubjectDistanceRange"),
+            // EXIF metadata versions / color space
+            AndroidExifTag(ExifInterface.TAG_EXIF_VERSION, "exif", "ExifVersion"),
+            AndroidExifTag(ExifInterface.TAG_FLASHPIX_VERSION, "exif", "FlashpixVersion"),
+            AndroidExifTag(ExifInterface.TAG_COLOR_SPACE, "exif", "ColorSpace"),
+            AndroidExifTag(ExifInterface.TAG_COMPONENTS_CONFIGURATION, "exif", "ComponentsConfiguration"),
+            // Camera lens
+            AndroidExifTag(ExifInterface.TAG_LENS_MAKE, "exif", "LensMake"),
+            AndroidExifTag(ExifInterface.TAG_LENS_MODEL, "exif", "LensModel"),
+            AndroidExifTag(ExifInterface.TAG_LENS_SERIAL_NUMBER, "exif", "LensSerialNumber"),
+            AndroidExifTag(ExifInterface.TAG_LENS_SPECIFICATION, "exif", "LensSpecification"),
+            AndroidExifTag(ExifInterface.TAG_BODY_SERIAL_NUMBER, "exif", "BodySerialNumber"),
+            AndroidExifTag(ExifInterface.TAG_CAMERA_OWNER_NAME, "exif", "CameraOwnerName"),
+            AndroidExifTag(ExifInterface.TAG_IMAGE_UNIQUE_ID, "exif", "ImageUniqueID"),
+            // GPS
+            AndroidExifTag(ExifInterface.TAG_GPS_VERSION_ID, "gps", "GPSVersionID"),
+            AndroidExifTag(ExifInterface.TAG_GPS_LATITUDE, "gps", "GPSLatitude"),
+            AndroidExifTag(ExifInterface.TAG_GPS_LATITUDE_REF, "gps", "GPSLatitudeRef"),
+            AndroidExifTag(ExifInterface.TAG_GPS_LONGITUDE, "gps", "GPSLongitude"),
+            AndroidExifTag(ExifInterface.TAG_GPS_LONGITUDE_REF, "gps", "GPSLongitudeRef"),
+            AndroidExifTag(ExifInterface.TAG_GPS_ALTITUDE, "gps", "GPSAltitude"),
+            AndroidExifTag(ExifInterface.TAG_GPS_ALTITUDE_REF, "gps", "GPSAltitudeRef"),
+            AndroidExifTag(ExifInterface.TAG_GPS_TIMESTAMP, "gps", "GPSTimeStamp"),
+            AndroidExifTag(ExifInterface.TAG_GPS_DATESTAMP, "gps", "GPSDateStamp"),
+        )
+    }
+}

--- a/packages/flutter_image_compress/example/integration_test/compress_test.dart
+++ b/packages/flutter_image_compress/example/integration_test/compress_test.dart
@@ -141,8 +141,10 @@ void main() {
 
       expect(result, isNotNull, reason: 'compressAndGetFile returned null');
       final outFile = File(result!.path);
-      expect(outFile.existsSync(), isTrue,
-          reason: 'output file was not written to disk',
+      expect(
+        outFile.existsSync(),
+        isTrue,
+        reason: 'output file was not written to disk',
       );
       final outBytes = await outFile.readAsBytes();
       expectValidCompressed(
@@ -213,8 +215,11 @@ void main() {
           minHeight: 300,
           quality: 85,
         );
-        expect(jpgResult, isNotNull,
-            reason: 'round-trip HEIC->JPEG returned null',);
+        expect(
+          jpgResult,
+          isNotNull,
+          reason: 'round-trip HEIC->JPEG returned null',
+        );
         final jpgBytes = await File(jpgResult!.path).readAsBytes();
         expectValidCompressed(
           bytes: jpgBytes,
@@ -265,8 +270,11 @@ void main() {
           );
           final baseDims = await decodeDimensions(base);
           final rotDims = await decodeDimensions(rotated);
-          expect(rotDims.width, approxEquals(baseDims.height),
-              reason: 'rotate=90 should swap width/height',);
+          expect(
+            rotDims.width,
+            approxEquals(baseDims.height),
+            reason: 'rotate=90 should swap width/height',
+          );
           expect(rotDims.height, approxEquals(baseDims.width));
         },
       );
@@ -344,9 +352,12 @@ void main() {
           quality: 85,
         );
         final dims = await decodeDimensions(result);
-        expect(dims.height, greaterThan(dims.width),
-            reason:
-                'output should be portrait (h>w) because source EXIF Orientation=6',);
+        expect(
+          dims.height,
+          greaterThan(dims.width),
+          reason:
+              'output should be portrait (h>w) because source EXIF Orientation=6',
+        );
       });
     },
     // macOS uses a different decode path (NSBitmapImageRep) which does not
@@ -362,8 +373,11 @@ void main() {
         final src = await loadAssetBytes('img/transparent-background.png');
         // Confirm the source really has transparent pixels somewhere —
         // otherwise the plugin's "preserved alpha" would be meaningless.
-        expect(await imageHasAlpha(src), isTrue,
-            reason: 'source PNG has no alpha < 255 anywhere — asset issue',);
+        expect(
+          await imageHasAlpha(src),
+          isTrue,
+          reason: 'source PNG has no alpha < 255 anywhere — asset issue',
+        );
 
         final result = await FlutterImageCompress.compressWithList(
           src,
@@ -379,9 +393,12 @@ void main() {
           description: 'transparent PNG',
         );
 
-        expect(await imageHasAlpha(result), isTrue,
-            reason:
-                'output PNG has no pixel with alpha<255 — alpha channel was dropped',);
+        expect(
+          await imageHasAlpha(result),
+          isTrue,
+          reason:
+              'output PNG has no pixel with alpha<255 — alpha channel was dropped',
+        );
       },
     );
   });
@@ -396,8 +413,11 @@ void main() {
           minHeight: 400,
           quality: 90,
         );
-        expect(result, isNotNull,
-            reason: 'compressAssetImage for WebP source returned null',);
+        expect(
+          result,
+          isNotNull,
+          reason: 'compressAssetImage for WebP source returned null',
+        );
         final bytes = Uint8List.fromList(result!);
         expectValidCompressed(
           bytes: bytes,
@@ -430,7 +450,8 @@ void main() {
         final srcKeys = (await readExifKeys(src)).toSet();
         if (srcKeys.isEmpty) {
           markTestSkipped(
-              'auto-angle.jpg has no EXIF metadata reachable via test helper',);
+            'auto-angle.jpg has no EXIF metadata reachable via test helper',
+          );
           return;
         }
 
@@ -451,16 +472,22 @@ void main() {
         final keptKeys = (await readExifKeys(kept)).toSet();
         final droppedKeys = (await readExifKeys(dropped)).toSet();
 
-        expect(keptKeys, isNotEmpty,
-            reason: 'keepExif=true should retain EXIF keys',);
+        expect(
+          keptKeys,
+          isNotEmpty,
+          reason: 'keepExif=true should retain EXIF keys',
+        );
         // The load-bearing invariant: keepExif=true retains at least one
         // source-provided EXIF key that keepExif=false does not emit.
         final retainedFromSource =
             keptKeys.intersection(srcKeys).difference(droppedKeys);
-        expect(retainedFromSource, isNotEmpty,
-            reason: 'keepExif=true should retain at least one source EXIF key '
-                'that keepExif=false does not emit '
-                '(src=$srcKeys kept=$keptKeys dropped=$droppedKeys)',);
+        expect(
+          retainedFromSource,
+          isNotEmpty,
+          reason: 'keepExif=true should retain at least one source EXIF key '
+              'that keepExif=false does not emit '
+              '(src=$srcKeys kept=$keptKeys dropped=$droppedKeys)',
+        );
       });
 
       testWidgets(
@@ -493,10 +520,13 @@ void main() {
           );
           final keptKeys = (await readExifKeys(kept)).toSet();
           final survivors = srcCanaries.intersection(keptKeys);
-          expect(survivors, srcCanaries,
-              reason: 'keepExif=true should preserve every DateTime-family '
-                  'EXIF/TIFF tag present in the source '
-                  '(src=$srcCanaries survived=$survivors kept=$keptKeys)',);
+          expect(
+            survivors,
+            srcCanaries,
+            reason: 'keepExif=true should preserve every DateTime-family '
+                'EXIF/TIFF tag present in the source '
+                '(src=$srcCanaries survived=$survivors kept=$keptKeys)',
+          );
         },
       );
 
@@ -510,7 +540,8 @@ void main() {
           final srcKeys = (await readExifKeys(src)).toSet();
           if (srcKeys.isEmpty) {
             markTestSkipped(
-                'auto-angle.jpg has no EXIF/TIFF metadata reachable via helper',);
+              'auto-angle.jpg has no EXIF/TIFF metadata reachable via helper',
+            );
             return;
           }
 
@@ -546,10 +577,12 @@ void main() {
             return;
           }
           final leaked = srcIdentifying.intersection(droppedKeys);
-          expect(leaked, isEmpty,
-              reason:
-                  'keepExif=false must not leak source identifying metadata '
-                  '(leaked=$leaked droppedKeys=$droppedKeys)',);
+          expect(
+            leaked,
+            isEmpty,
+            reason: 'keepExif=false must not leak source identifying metadata '
+                '(leaked=$leaked droppedKeys=$droppedKeys)',
+          );
         },
       );
 
@@ -603,28 +636,49 @@ void main() {
             format: CompressFormat.heic,
             keepExif: true,
           );
+          // Bytes-validity assertion runs on every platform — Android
+          // included — even though the metadata-survival check below
+          // cannot: HEIC + keepExif on Android is not expected to preserve
+          // EXIF (see HeifHandler.warnKeepExifUnsupported), but the
+          // encoder must still produce a valid HEIC file.
           expectValidCompressed(
             bytes: result,
             expected: DetectedFormat.heic,
             description: 'HEIC + keepExif',
           );
 
+          // Metadata survival is only asserted on iOS/macOS. Android has
+          // no in-tree library that writes EXIF into HEIF/HEIC containers —
+          // androidx.exifinterface's saveAttributes refuses image/heic
+          // explicitly ("ExifInterface only supports saving attributes for
+          // JPEG, PNG, and WebP formats"), and there is no MediaMuxer /
+          // HeifWriter path that authors HEIF metadata boxes. HeifHandler
+          // logs a clear warning for this combination. See README's
+          // "keepExif" section for the platform matrix.
+          if (Platform.isAndroid) {
+            return;
+          }
+
           // Only assert metadata survival when the source carries one of
           // the canary tags — some CI base images may strip them.
           if (srcCanaries.isNotEmpty) {
             final keptKeys = (await readExifKeys(result)).toSet();
             final survivors = srcCanaries.intersection(keptKeys);
-            expect(survivors, srcCanaries,
-                reason: 'HEIC + keepExif=true should preserve DateTime tags '
-                    '(src=$srcCanaries survived=$survivors kept=$keptKeys)',);
+            expect(
+              survivors,
+              srcCanaries,
+              reason: 'HEIC + keepExif=true should preserve DateTime tags '
+                  '(src=$srcCanaries survived=$survivors kept=$keptKeys)',
+            );
           }
         },
       );
     },
     // Now that macOS pumps source properties through as nested sub-dicts
     // (matching iOS's direct passthrough), the keepExif invariants run on
-    // both platforms. The WebP-inner test stays iOS-only because the
-    // macOS package doesn't ship the WebP coder.
-    skip: !(Platform.isIOS || Platform.isMacOS),
+    // iOS + macOS + Android. The WebP-inner test stays iOS-only because
+    // the macOS package doesn't ship the WebP coder; Android does support
+    // WebP but its keepExif path is being fixed in a separate PR.
+    skip: !(Platform.isIOS || Platform.isMacOS || Platform.isAndroid),
   );
 }

--- a/packages/flutter_image_compress_common/android/src/main/kotlin/com/fluttercandies/flutter_image_compress/handle/heif/HeifHandler.kt
+++ b/packages/flutter_image_compress_common/android/src/main/kotlin/com/fluttercandies/flutter_image_compress/handle/heif/HeifHandler.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.os.Build
+import android.util.Log
 import androidx.heifwriter.HeifWriter
 import com.fluttercandies.flutter_image_compress.ext.calcScale
 import com.fluttercandies.flutter_image_compress.ext.rotate
@@ -32,6 +33,10 @@ class HeifHandler : FormatHandler {
         val tmpFile = TmpFileUtil.createTmpFile(context)
         try {
             compress(byteArray, minWidth, minHeight, quality, rotate, inSampleSize, tmpFile.absolutePath)
+            // Warn only after compression actually produced a HEIC — otherwise
+            // a HeifWriter failure (OOM, missing hardware encoder) gets
+            // misattributed to the keepExif path in bug triage.
+            warnKeepExifUnsupported(keepExif)
             outputStream.write(tmpFile.readBytes())
         } finally {
             tmpFile.delete()
@@ -143,9 +148,34 @@ class HeifHandler : FormatHandler {
         val tmpFile = TmpFileUtil.createTmpFile(context)
         try {
             compress(path, minWidth, minHeight, quality, rotate, inSampleSize, tmpFile.absolutePath)
+            warnKeepExifUnsupported(keepExif)
             outputStream.write(tmpFile.readBytes())
         } finally {
             tmpFile.delete()
+        }
+    }
+
+    // The `keepExif` parameter used to be silently ignored on the HEIC path
+    // (parameter received, never read). That is still the runtime behaviour,
+    // but is now discoverable via Log.w (which surfaces to `adb logcat`
+    // regardless of the plugin's `showLog` flag): androidx.exifinterface
+    // refuses to write EXIF to HEIF/HEIC containers ("ExifInterface only
+    // supports saving attributes for JPEG, PNG, and WebP formats"), and
+    // Android does not ship an alternative library that authors HEIF
+    // metadata boxes. Manual ISO/IEC 23008-12 box injection would be
+    // ~400 LOC and is tracked as a follow-up on issue #130.
+    // Users asking for `keepExif=true` on HEIC get a valid HEIC without
+    // EXIF instead of a crash or malformed output. See README's
+    // "keepExif" section for the platform matrix.
+    private fun warnKeepExifUnsupported(keepExif: Boolean) {
+        if (keepExif) {
+            Log.w(
+                "FlutterImageCompress",
+                "keepExif=true is not supported for HEIC output on Android " +
+                        "(androidx.exifinterface cannot save attributes to HEIF/HEIC). " +
+                        "The compressed HEIC is valid but does not carry EXIF metadata. " +
+                        "See https://github.com/fluttercandies/flutter_image_compress/issues/130"
+            )
         }
     }
 }


### PR DESCRIPTION
Partially addresses **#130** — the Android side of \"support more EXIF attributes\" ends up being three separate problems, and this PR is the first of them.

## Context

`HeifHandler` on Android accepts `keepExif: Boolean` from Dart but has always silently ignored it. Two rounds of verification:

1. **Empirical**: added an Android integration test with a canary tag list (see `MainActivity.kt` test-only channel), ran on Android emulator (API 36) — the source's `exif:DateTimeOriginal`, `exif:DateTimeDigitized`, `tiff:DateTime` all disappear from the HEIC output.
2. **Bytecode**: extracted `exifinterface-1.4.2.aar` from Gradle cache and disassembled `ExifInterface.class`. `saveAttributes()` throws `IOException(\"ExifInterface only supports saving attributes for JPEG, PNG, and WebP formats.\")` for HEIF/HEIC. Confirmed identical behaviour in 1.3.3 (the version we currently ship).

The framework `android.media.ExifInterface` is even more restrictive (JPEG-only). There's no in-tree library that writes EXIF into HEIF/HEIC containers.

## What this PR does — and doesn't

**Does**:
- `HeifHandler.warnKeepExifUnsupported` — emits `Log.w(\"FlutterImageCompress\", ...)` when `keepExif=true` on the HEIC path. `Log.w` surfaces to `adb logcat` regardless of the plugin's `showLog` flag (which defaults `false`), so users can actually see the warning. Fires *after* the HEIC file is produced, so a HeifWriter OOM / missing-hardware-encoder failure does not get misattributed to the keepExif branch in triage.
- **README's `keepExif` section**: replaces the vague \"only support jpg\" claim with an explicit per-format-per-platform matrix that honestly names Android PNG/WebP/HEIC as ❌ and points at #130.
- **Integration-test split**: HEIC + `keepExif=true` bytes-validity assertion now runs on Android too — the file must still be a valid HEIC container even when EXIF cannot be written. The metadata-survival assertion is early-returned on Android with a clear comment.
- **New Android test-helper channel** (`flutter_image_compress/test` in `MainActivity.kt`) mirrors iOS/macOS `example/shared/ExifTestHelper.swift`. Enumerates ~70 EXIF/TIFF/GPS tags that `ExifKeeper` preserves so a future shrink of `ExifKeeper`'s attribute list stays visible to the test — a narrower list would let a regression pass silently by not looking at the dropped tags.
- Example app's `build.gradle.kts` explicitly depends on `androidx.exifinterface 1.3.3` (matches the plugin's `implementation`-scoped dep, pinned with a KEEP-IN-SYNC comment).

**Does NOT**:
- **Actually preserve HEIC EXIF on Android.** That would require ~400 LOC of ISO/IEC 23008-12 box injection (add `infe` item_type='Exif' to `iinf`, `iloc` mdat entry with 4-byte TIFF-offset prefix, `iref cdsc` from the Exif item to the primary image). Left as follow-up on #130.

## Follow-ups planned on #130

- Android PNG + WebP `keepExif` — `CommonHandler.kt`'s `bitmapFormat == JPEG` guard drops EXIF on those formats even though `androidx.exifinterface` supports writing to them. **Next PR**.
- Web + OHOS `keepExif` — platform-native limitations, docs update only.
- iOS WebP `keepExif` — ImageIO cannot author WebP metadata; docs already reflect this.

## Test plan

- [x] `melos run format`
- [x] `melos run analyze`
- [x] Android emulator (API 36): all 5 keepExif tests pass; HEIC + keepExif skipped-with-return; new tag helper reads back all preserved tags.
- [x] iOS 26.5 simulator: all 5 keepExif tests pass — my Android early-return branch is inert on iOS.
- [x] Adversarial subagent review — caught: log gated on `showLog` (fixed → `Log.w`), warn before compression (fixed → moved after), narrow tag list (fixed → expanded to ~70), silent cast failure (fixed → explicit error), README count wrong (fixed → ~90), test skipping too much (fixed → split into bytes-validity + survival), version drift risk (mitigated with comment)
- [x] CI: iOS/macOS both integration flavors, Android build, Web build

Refs #130.

🤖 Generated with [Claude Code](https://claude.com/claude-code)