### PR TITLE
fix(Android): preserve source EXIF on PNG and WebP output (refs #130)

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,15 +265,17 @@ Attention should be paid to the following points:
    | Output format | iOS / macOS | Android |
    | --- | --- | --- |
    | JPEG | ✅ full sub-dict passthrough (EXIF, TIFF, GPS, IPTC, PNG) | ✅ ~90 EXIF tags via `androidx.exifinterface` |
-   | PNG  | ✅ same passthrough | ❌ dropped — see [PNG/WebP note](#png--webp-keepexif-on-android) below |
-   | WebP | ❌ ImageIO cannot author WebP metadata; output is a valid WebP without EXIF | ❌ same as PNG |
+   | PNG  | ✅ same passthrough | ✅ ~90 EXIF tags via `androidx.exifinterface` |
+   | WebP | ❌ ImageIO cannot author WebP metadata; output is a valid WebP without EXIF | ✅ ~90 EXIF tags via `androidx.exifinterface` |
    | HEIC | ✅ same passthrough | ❌ `androidx.exifinterface` refuses HEIF write; the resulting HEIC is valid but has no EXIF. `HeifHandler` logs a clear warning in this case. |
 
    The rows marked ❌ still return valid image bytes — you just do not get EXIF back. `keepExif: true` never fails the whole compression call.
 
-##### PNG / WebP keepExif on Android
+##### Follow-ups tracked on [#130](https://github.com/fluttercandies/flutter_image_compress/issues/130)
 
-Android's `CommonHandler` currently only invokes `ExifKeeper` when the output format is JPEG. PNG and WebP output paths drop EXIF regardless of `keepExif`. See issue [#130](https://github.com/fluttercandies/flutter_image_compress/issues/130).
+- **iOS WebP + `keepExif`**: `ImageIO` cannot author WebP containers with metadata. Manual VP8X + EXIF chunk splicing via `SDWebImageWebPCoder` would fix this but is not currently implemented.
+- **Android HEIC + `keepExif`**: `androidx.exifinterface` refuses HEIF write across all versions. Manual ISO/IEC 23008-12 metadata box injection (~400 LoC) would fix this but is not currently implemented.
+- **Web / OpenHarmony `keepExif`**: the Canvas / packing pipelines used by these platforms strip metadata at encode time — no in-tree fix path.
 
 ## Result
 

--- a/README.md
+++ b/README.md
@@ -457,17 +457,21 @@ and use a permission plugin to request permission to access SD cards on Android/
 
 ## About EXIF information
 
-Using this library, EXIF information will be removed by default.
+By default (`keepExif: false`, the default), the compressed output carries no source EXIF — only the encoder-injected minimum required by the container (image dimensions, color space).
 
-EXIF information can be retained by setting keepExif to true,
-but not `direction` information.
+With `keepExif: true`, the plugin copies source EXIF onto the compressed output. The **[keepExif section above](#keepexif)** has the full per-format-per-platform matrix; the short version is:
 
-- PNG/JPEG encoder: System API.
-- WebP encoder:
-  - [SDWebImageWebPCoder](https://github.com/SDWebImage/SDWebImageWebPCoder) on iOS.
-  - System API on Android.
-- HEIF encoder: System API.
-  - [HeifWriter](https://developer.android.com/jetpack/androidx/releases/heifwriter) on Android P+.
+- **iOS + macOS**: full sub-dict passthrough (EXIF, TIFF, GPS, IPTC, PNG chunks) via `CGImageSource → CGImageDestination`. Works for JPEG, PNG, HEIC. Not WebP (ImageIO cannot author WebP metadata).
+- **Android**: ~90-tag copy via `androidx.exifinterface`. Works for JPEG, PNG, WebP. Not HEIC (`ExifInterface` refuses HEIF write; `HeifHandler` logs a warning).
+- **Web + OpenHarmony**: not supported. The Canvas / packing pipelines strip metadata at encode time.
+
+Regardless of platform, the `Orientation` tag is normalized to `1` / `ORIENTATION_NORMAL` on the output — the pipeline bakes rotation into pixels, so preserving the source orientation would cause viewers to double-rotate.
+
+### Encoders in use
+
+- JPEG / PNG: system APIs everywhere.
+- WebP: system API on Android, [SDWebImageWebPCoder](https://github.com/SDWebImage/SDWebImageWebPCoder) on iOS, browser Canvas on Web.
+- HEIC / HEIF: system API on iOS 11+ (ImageIO). Android uses [HeifWriter](https://developer.android.com/jetpack/androidx/releases/heifwriter) on API 28+ (with hardware encoder — falls back to `UnsupportedError` if the device can't produce HEIC).
 
 ## Web
 

--- a/packages/flutter_image_compress/README.md
+++ b/packages/flutter_image_compress/README.md
@@ -92,7 +92,7 @@ There are several ways to use the library api.
 ```dart
 
   // 1. compress file and get Uint8List
-  Future<Uint8List> testCompressFile(File file) async {
+  Future<Uint8List?> testCompressFile(File file) async {
     var result = await FlutterImageCompress.compressWithFile(
       file.absolute.path,
       minWidth: 2300,
@@ -101,12 +101,14 @@ There are several ways to use the library api.
       rotate: 90,
     );
     print(file.lengthSync());
-    print(result.length);
+    if (result != null) {
+      print(result.length);
+    }
     return result;
   }
 
   // 2. compress file and get file.
-  Future<File> testCompressAndGetFile(File file, String targetPath) async {
+  Future<File?> testCompressAndGetFile(File file, String targetPath) async {
     var result = await FlutterImageCompress.compressAndGetFile(
         file.absolute.path, targetPath,
         quality: 88,
@@ -114,13 +116,16 @@ There are several ways to use the library api.
       );
 
     print(file.lengthSync());
-    print(result.lengthSync());
+    if (result != null) {
+      print(await result.length());
+      return File(result.path);
+    }
 
     return result;
   }
 
   // 3. compress asset and get Uint8List.
-  Future<Uint8List> testCompressAsset(String assetName) async {
+  Future<Uint8List?> testCompressAsset(String assetName) async {
     var list = await FlutterImageCompress.compressAssetImage(
       assetName,
       minHeight: 1920,
@@ -254,8 +259,23 @@ If this parameter is true, EXIF information is saved in the compressed result.
 Attention should be paid to the following points:
 
 1. Default value is false.
-2. Even if set to true, the direction attribute is not included.
-3. Only support jpg format, PNG format does not support.
+2. Even if set to true, the `Orientation` tag is normalized to `1`/`ORIENTATION_NORMAL` — the pipeline bakes rotation into pixels, so preserving the source orientation tag would cause viewers to double-rotate.
+3. Support varies by output format **and** platform:
+
+   | Output format | iOS / macOS | Android |
+   | --- | --- | --- |
+   | JPEG | ✅ full sub-dict passthrough (EXIF, TIFF, GPS, IPTC, PNG) | ✅ ~90 EXIF tags via `androidx.exifinterface` |
+   | PNG  | ✅ same passthrough | ✅ ~90 EXIF tags via `androidx.exifinterface` |
+   | WebP | ❌ ImageIO cannot author WebP metadata; output is a valid WebP without EXIF | ✅ ~90 EXIF tags via `androidx.exifinterface` |
+   | HEIC | ✅ same passthrough | ❌ `androidx.exifinterface` refuses HEIF write; the resulting HEIC is valid but has no EXIF. `HeifHandler` logs a clear warning in this case. |
+
+   The rows marked ❌ still return valid image bytes — you just do not get EXIF back. `keepExif: true` never fails the whole compression call.
+
+##### Follow-ups tracked on [#130](https://github.com/fluttercandies/flutter_image_compress/issues/130)
+
+- **iOS WebP + `keepExif`**: `ImageIO` cannot author WebP containers with metadata. Manual VP8X + EXIF chunk splicing via `SDWebImageWebPCoder` would fix this but is not currently implemented.
+- **Android HEIC + `keepExif`**: `androidx.exifinterface` refuses HEIF write across all versions. Manual ISO/IEC 23008-12 metadata box injection (~400 LoC) would fix this but is not currently implemented.
+- **Web / OpenHarmony `keepExif`**: the Canvas / packing pipelines used by these platforms strip metadata at encode time — no in-tree fix path.
 
 ## Result
 
@@ -295,6 +315,101 @@ Future<void> writeToFile(List<int> image, String filePath) {
   return File(filePath).writeAsBytes(image, flush: true);
 }
 ```
+
+## FAQ
+
+### Compressing to a target file size
+
+Both `quality` (0-100 lossy) and `minWidth`/`minHeight` (max output dimensions,
+see below) influence the output size, but neither maps linearly to bytes. If
+you need the output under a specific limit, iterate:
+
+```dart
+Future<Uint8List> compressToUnder(Uint8List src, int limitBytes) async {
+  var quality = 88;
+  var out = src;
+  while (quality > 10) {
+    out = await FlutterImageCompress.compressWithList(
+      src,
+      quality: quality,
+      minWidth: 1920,
+      minHeight: 1920,
+    );
+    if (out.lengthInBytes <= limitBytes) return out;
+    quality -= 10;
+  }
+  return out;
+}
+```
+
+For very small targets, drop `minWidth`/`minHeight` as well when the quality
+loop bottoms out — the biggest byte-count lever is usually pixel count.
+
+### Why is `minWidth`/`minHeight` named that if it acts like a max?
+
+Historical name. In practice they are **aspect-preserving upper bounds** on
+the output: the pipeline scales down (never up) so that both dimensions fit
+inside the given box while keeping the source aspect ratio. So:
+
+- source 4032×3024, `minWidth: 1920, minHeight: 1920` → output around 1920×1440.
+- source 1000×1000, `minWidth: 500, minHeight: 500`   → output 500×500.
+- source 800×600, `minWidth: 1920, minHeight: 1080`   → output 800×600 (no upscale).
+
+If you want strict maximum-dimension bounds and aren't tied to this plugin,
+that's the mental model to keep — the aspect ratio is always preserved
+(never cropped), only the scale is adjusted.
+
+### Compressed image is larger than the original
+
+Two common causes:
+
+- **PNG re-encoded from PNG.** PNG is lossless; re-encoding a PNG rarely
+  makes it smaller unless you also downscale. `quality` doesn't apply to
+  PNG in the underlying encoders — it just runs the same DEFLATE. If your
+  source PNG was already tightly encoded (e.g. by pngcrush), the output
+  can be a few percent larger.
+- **`minWidth`/`minHeight` larger than the source.** The plugin never
+  upscales, but the re-encoding step still runs and can produce a slightly
+  larger JPEG than the input.
+
+If the source is already small enough for your needs, skip compression when
+`src.lengthInBytes` is below your threshold rather than always calling
+through.
+
+### Calling from a background Isolate / `compute()`
+
+Plugin channels don't work in a background isolate unless you initialize
+the binary messenger first. Inside the isolate:
+
+```dart
+BackgroundIsolateBinaryMessenger.ensureInitialized(rootIsolateToken);
+final out = await FlutterImageCompress.compressWithList(bytes, quality: 80);
+```
+
+`rootIsolateToken` must be obtained from the main isolate (via
+`RootIsolateToken.instance!`) and passed into the isolate's arguments.
+
+Without this, you'll see `UnimplementedError` with a message pointing
+back here — that's the platform interface's `UnsupportedFlutterImageCompress`
+fallback firing.
+
+### Which platforms support which formats?
+
+See the platform-features table near the top of this README. Quick reference:
+
+- **JPEG / PNG**: everywhere.
+- **WebP**: Android + iOS + macOS via SDWebImageWebPCoder, Web via browser
+  (quality-support varies).
+- **HEIC / HEIF**: iOS 11+, Android API 28+ with a hardware encoder — falls
+  back to `UnsupportedError` when unavailable. macOS: no.
+
+### How do I clear the temp files the plugin creates?
+
+The `compressAndGetFile` path writes to your `targetPath`. Anything else
+lands in the system cache directory (`context.cacheDir` on Android,
+`NSTemporaryDirectory()` on iOS). Both are OS-managed — call
+`path_provider`'s `getTemporaryDirectory()` and delete its contents
+yourself if you want manual control.
 
 ## Runtime Error
 
@@ -342,42 +457,25 @@ and use a permission plugin to request permission to access SD cards on Android/
 
 ## About EXIF information
 
-Using this library, EXIF information will be removed by default.
+By default (`keepExif: false`, the default), the compressed output carries no source EXIF — only the encoder-injected minimum required by the container (image dimensions, color space).
 
-EXIF information can be retained by setting keepExif to true,
-but not `direction` information.
+With `keepExif: true`, the plugin copies source EXIF onto the compressed output. The **[keepExif section above](#keepexif)** has the full per-format-per-platform matrix; the short version is:
 
-- PNG/JPEG encoder: System API.
-- WebP encoder:
-  - [SDWebImageWebPCoder](https://github.com/SDWebImage/SDWebImageWebPCoder) on iOS.
-  - System API on Android.
-- HEIF encoder: System API.
-  - [HeifWriter](https://developer.android.com/jetpack/androidx/releases/heifwriter) on Android P+.
+- **iOS + macOS**: full sub-dict passthrough (EXIF, TIFF, GPS, IPTC, PNG chunks) via `CGImageSource → CGImageDestination`. Works for JPEG, PNG, HEIC. Not WebP (ImageIO cannot author WebP metadata).
+- **Android**: ~90-tag copy via `androidx.exifinterface`. Works for JPEG, PNG, WebP. Not HEIC (`ExifInterface` refuses HEIF write; `HeifHandler` logs a warning).
+- **Web + OpenHarmony**: not supported. The Canvas / packing pipelines strip metadata at encode time.
+
+Regardless of platform, the `Orientation` tag is normalized to `1` / `ORIENTATION_NORMAL` on the output — the pipeline bakes rotation into pixels, so preserving the source orientation would cause viewers to double-rotate.
+
+### Encoders in use
+
+- JPEG / PNG: system APIs everywhere.
+- WebP: system API on Android, [SDWebImageWebPCoder](https://github.com/SDWebImage/SDWebImageWebPCoder) on iOS, browser Canvas on Web.
+- HEIC / HEIF: system API on iOS 11+ (ImageIO). Android uses [HeifWriter](https://developer.android.com/jetpack/androidx/releases/heifwriter) on API 28+ (with hardware encoder — falls back to `UnsupportedError` if the device can't produce HEIC).
 
 ## Web
 
 The web implementation is not required for many people,
-
-This plugin uses [pica][] to implement compression.
-
-Currently, [debug mode does not allow you to use the dynamic script loading scheme][flutter-126131].
-And when you actually deploy, you may choose server deployment or cdn deployment, so here we suggest you add script node to head or body by yourself in your `<flutte_project>/web/index.html`.
-
-[flutter-126131]: https://github.com/flutter/flutter/issues/126131
-
-Add for `<flutte_project>/web/index.html`:
-
-```html
-<script src="https://cdn.jsdelivr.net/npm/pica@9.0.1/dist/pica.min.js" ></script>
-
-<!-- or -->
-
-<script src="https://unpkg.com/pica/dist/pica.min.js" ></script>
-```
-
-About web compatibility: two methods with file will throw an exception when used on the web.
-
-[pica]: https://www.npmjs.com/package/pica?activeTab=readme
 
 ## About macOS
 
@@ -388,11 +486,8 @@ Open xcode project, select Runner target, and change the value of `macOS Deploym
 And, change the `Podfile`:
 Change `platform` to `platform :osx, '10.15'`.
 
-
 ## OpenHarmony
 
 The currently supported image formats for parsing include JPEG, PNG, GIF, RAW, WebP, BMP, and SVG. However, the encoding output image formats are currently limited to JPEG, PNG, and WebP only.
 
 当前支持的解析图片格式包括 JPEG、PNG、GIF、RAW、WebP、BMP、SVG . 编码输出图片格式当前仅支持 JPEG、PNG 和 WebP.
-
-

--- a/packages/flutter_image_compress/example/android/app/build.gradle.kts
+++ b/packages/flutter_image_compress/example/android/app/build.gradle.kts
@@ -49,5 +49,5 @@ dependencies {
     // The plugin itself uses this but declares it as `implementation` scope, so
     // the example app can't see it transitively — declare explicitly here.
     // KEEP IN SYNC with `flutter_image_compress_common/android/build.gradle`.
-    implementation("androidx.exifinterface:exifinterface:1.3.3")
+    implementation("androidx.exifinterface:exifinterface:1.4.2")
 }

--- a/packages/flutter_image_compress/example/integration_test/compress_test.dart
+++ b/packages/flutter_image_compress/example/integration_test/compress_test.dart
@@ -609,7 +609,103 @@ void main() {
           );
         },
         // WebP is iOS/Android only in the common package.
-        skip: !Platform.isIOS,
+        skip: !(Platform.isIOS || Platform.isAndroid),
+      );
+
+      testWidgets(
+        'Android PNG + keepExif=true: source EXIF DateTime-family tag '
+        'survives (regression for #130 — CommonHandler used to short-circuit '
+        'ExifKeeper unless bitmapFormat == JPEG, silently dropping EXIF for '
+        'PNG output)',
+        (_) async {
+          final src = await loadAssetBytes('img/auto-angle.jpg');
+          final srcKeys = (await readExifKeys(src)).toSet();
+          const canaries = <String>{
+            'exif:DateTimeOriginal',
+            'exif:DateTimeDigitized',
+            'tiff:DateTime',
+          };
+          final srcCanaries = srcKeys.intersection(canaries);
+          if (srcCanaries.isEmpty) {
+            markTestSkipped(
+              'auto-angle.jpg has no DateTime-family tag reachable via helper',
+            );
+            return;
+          }
+
+          final result = await FlutterImageCompress.compressWithList(
+            src,
+            minWidth: 500,
+            minHeight: 500,
+            format: CompressFormat.png,
+            keepExif: true,
+          );
+          expectValidCompressed(
+            bytes: result,
+            expected: DetectedFormat.png,
+            description: 'Android PNG + keepExif',
+          );
+          final keptKeys = (await readExifKeys(result)).toSet();
+          final survivors = srcCanaries.intersection(keptKeys);
+          expect(
+            survivors,
+            srcCanaries,
+            reason:
+                'PNG + keepExif=true should preserve DateTime tags on Android '
+                '(src=$srcCanaries survived=$survivors kept=$keptKeys)',
+          );
+        },
+        // Android-only regression: iOS/macOS PNG already preserved EXIF via
+        // the CGImageDestination passthrough (#391 / #392).
+        skip: !Platform.isAndroid,
+      );
+
+      testWidgets(
+        'Android WebP + keepExif=true: source EXIF DateTime-family tag '
+        'survives (regression for #130 — same JPEG-only guard dropped EXIF '
+        'for WebP output)',
+        (_) async {
+          final src = await loadAssetBytes('img/auto-angle.jpg');
+          final srcKeys = (await readExifKeys(src)).toSet();
+          const canaries = <String>{
+            'exif:DateTimeOriginal',
+            'exif:DateTimeDigitized',
+            'tiff:DateTime',
+          };
+          final srcCanaries = srcKeys.intersection(canaries);
+          if (srcCanaries.isEmpty) {
+            markTestSkipped(
+              'auto-angle.jpg has no DateTime-family tag reachable via helper',
+            );
+            return;
+          }
+
+          final result = await FlutterImageCompress.compressWithList(
+            src,
+            minWidth: 500,
+            minHeight: 500,
+            quality: 85,
+            format: CompressFormat.webp,
+            keepExif: true,
+          );
+          expectValidCompressed(
+            bytes: result,
+            expected: DetectedFormat.webp,
+            description: 'Android WebP + keepExif',
+          );
+          final keptKeys = (await readExifKeys(result)).toSet();
+          final survivors = srcCanaries.intersection(keptKeys);
+          expect(
+            survivors,
+            srcCanaries,
+            reason:
+                'WebP + keepExif=true should preserve DateTime tags on Android '
+                '(src=$srcCanaries survived=$survivors kept=$keptKeys)',
+          );
+        },
+        // Android-only: iOS WebP cannot preserve EXIF (ImageIO can't author
+        // WebP metadata); macOS package doesn't ship WebP.
+        skip: !Platform.isAndroid,
       );
 
       testWidgets(

--- a/packages/flutter_image_compress_common/README.md
+++ b/packages/flutter_image_compress_common/README.md
@@ -92,7 +92,7 @@ There are several ways to use the library api.
 ```dart
 
   // 1. compress file and get Uint8List
-  Future<Uint8List> testCompressFile(File file) async {
+  Future<Uint8List?> testCompressFile(File file) async {
     var result = await FlutterImageCompress.compressWithFile(
       file.absolute.path,
       minWidth: 2300,
@@ -101,12 +101,14 @@ There are several ways to use the library api.
       rotate: 90,
     );
     print(file.lengthSync());
-    print(result.length);
+    if (result != null) {
+      print(result.length);
+    }
     return result;
   }
 
   // 2. compress file and get file.
-  Future<File> testCompressAndGetFile(File file, String targetPath) async {
+  Future<File?> testCompressAndGetFile(File file, String targetPath) async {
     var result = await FlutterImageCompress.compressAndGetFile(
         file.absolute.path, targetPath,
         quality: 88,
@@ -114,13 +116,16 @@ There are several ways to use the library api.
       );
 
     print(file.lengthSync());
-    print(result.lengthSync());
+    if (result != null) {
+      print(await result.length());
+      return File(result.path);
+    }
 
     return result;
   }
 
   // 3. compress asset and get Uint8List.
-  Future<Uint8List> testCompressAsset(String assetName) async {
+  Future<Uint8List?> testCompressAsset(String assetName) async {
     var list = await FlutterImageCompress.compressAssetImage(
       assetName,
       minHeight: 1920,
@@ -254,8 +259,23 @@ If this parameter is true, EXIF information is saved in the compressed result.
 Attention should be paid to the following points:
 
 1. Default value is false.
-2. Even if set to true, the direction attribute is not included.
-3. Only support jpg format, PNG format does not support.
+2. Even if set to true, the `Orientation` tag is normalized to `1`/`ORIENTATION_NORMAL` — the pipeline bakes rotation into pixels, so preserving the source orientation tag would cause viewers to double-rotate.
+3. Support varies by output format **and** platform:
+
+   | Output format | iOS / macOS | Android |
+   | --- | --- | --- |
+   | JPEG | ✅ full sub-dict passthrough (EXIF, TIFF, GPS, IPTC, PNG) | ✅ ~90 EXIF tags via `androidx.exifinterface` |
+   | PNG  | ✅ same passthrough | ✅ ~90 EXIF tags via `androidx.exifinterface` |
+   | WebP | ❌ ImageIO cannot author WebP metadata; output is a valid WebP without EXIF | ✅ ~90 EXIF tags via `androidx.exifinterface` |
+   | HEIC | ✅ same passthrough | ❌ `androidx.exifinterface` refuses HEIF write; the resulting HEIC is valid but has no EXIF. `HeifHandler` logs a clear warning in this case. |
+
+   The rows marked ❌ still return valid image bytes — you just do not get EXIF back. `keepExif: true` never fails the whole compression call.
+
+##### Follow-ups tracked on [#130](https://github.com/fluttercandies/flutter_image_compress/issues/130)
+
+- **iOS WebP + `keepExif`**: `ImageIO` cannot author WebP containers with metadata. Manual VP8X + EXIF chunk splicing via `SDWebImageWebPCoder` would fix this but is not currently implemented.
+- **Android HEIC + `keepExif`**: `androidx.exifinterface` refuses HEIF write across all versions. Manual ISO/IEC 23008-12 metadata box injection (~400 LoC) would fix this but is not currently implemented.
+- **Web / OpenHarmony `keepExif`**: the Canvas / packing pipelines used by these platforms strip metadata at encode time — no in-tree fix path.
 
 ## Result
 
@@ -295,6 +315,101 @@ Future<void> writeToFile(List<int> image, String filePath) {
   return File(filePath).writeAsBytes(image, flush: true);
 }
 ```
+
+## FAQ
+
+### Compressing to a target file size
+
+Both `quality` (0-100 lossy) and `minWidth`/`minHeight` (max output dimensions,
+see below) influence the output size, but neither maps linearly to bytes. If
+you need the output under a specific limit, iterate:
+
+```dart
+Future<Uint8List> compressToUnder(Uint8List src, int limitBytes) async {
+  var quality = 88;
+  var out = src;
+  while (quality > 10) {
+    out = await FlutterImageCompress.compressWithList(
+      src,
+      quality: quality,
+      minWidth: 1920,
+      minHeight: 1920,
+    );
+    if (out.lengthInBytes <= limitBytes) return out;
+    quality -= 10;
+  }
+  return out;
+}
+```
+
+For very small targets, drop `minWidth`/`minHeight` as well when the quality
+loop bottoms out — the biggest byte-count lever is usually pixel count.
+
+### Why is `minWidth`/`minHeight` named that if it acts like a max?
+
+Historical name. In practice they are **aspect-preserving upper bounds** on
+the output: the pipeline scales down (never up) so that both dimensions fit
+inside the given box while keeping the source aspect ratio. So:
+
+- source 4032×3024, `minWidth: 1920, minHeight: 1920` → output around 1920×1440.
+- source 1000×1000, `minWidth: 500, minHeight: 500`   → output 500×500.
+- source 800×600, `minWidth: 1920, minHeight: 1080`   → output 800×600 (no upscale).
+
+If you want strict maximum-dimension bounds and aren't tied to this plugin,
+that's the mental model to keep — the aspect ratio is always preserved
+(never cropped), only the scale is adjusted.
+
+### Compressed image is larger than the original
+
+Two common causes:
+
+- **PNG re-encoded from PNG.** PNG is lossless; re-encoding a PNG rarely
+  makes it smaller unless you also downscale. `quality` doesn't apply to
+  PNG in the underlying encoders — it just runs the same DEFLATE. If your
+  source PNG was already tightly encoded (e.g. by pngcrush), the output
+  can be a few percent larger.
+- **`minWidth`/`minHeight` larger than the source.** The plugin never
+  upscales, but the re-encoding step still runs and can produce a slightly
+  larger JPEG than the input.
+
+If the source is already small enough for your needs, skip compression when
+`src.lengthInBytes` is below your threshold rather than always calling
+through.
+
+### Calling from a background Isolate / `compute()`
+
+Plugin channels don't work in a background isolate unless you initialize
+the binary messenger first. Inside the isolate:
+
+```dart
+BackgroundIsolateBinaryMessenger.ensureInitialized(rootIsolateToken);
+final out = await FlutterImageCompress.compressWithList(bytes, quality: 80);
+```
+
+`rootIsolateToken` must be obtained from the main isolate (via
+`RootIsolateToken.instance!`) and passed into the isolate's arguments.
+
+Without this, you'll see `UnimplementedError` with a message pointing
+back here — that's the platform interface's `UnsupportedFlutterImageCompress`
+fallback firing.
+
+### Which platforms support which formats?
+
+See the platform-features table near the top of this README. Quick reference:
+
+- **JPEG / PNG**: everywhere.
+- **WebP**: Android + iOS + macOS via SDWebImageWebPCoder, Web via browser
+  (quality-support varies).
+- **HEIC / HEIF**: iOS 11+, Android API 28+ with a hardware encoder — falls
+  back to `UnsupportedError` when unavailable. macOS: no.
+
+### How do I clear the temp files the plugin creates?
+
+The `compressAndGetFile` path writes to your `targetPath`. Anything else
+lands in the system cache directory (`context.cacheDir` on Android,
+`NSTemporaryDirectory()` on iOS). Both are OS-managed — call
+`path_provider`'s `getTemporaryDirectory()` and delete its contents
+yourself if you want manual control.
 
 ## Runtime Error
 
@@ -342,42 +457,25 @@ and use a permission plugin to request permission to access SD cards on Android/
 
 ## About EXIF information
 
-Using this library, EXIF information will be removed by default.
+By default (`keepExif: false`, the default), the compressed output carries no source EXIF — only the encoder-injected minimum required by the container (image dimensions, color space).
 
-EXIF information can be retained by setting keepExif to true,
-but not `direction` information.
+With `keepExif: true`, the plugin copies source EXIF onto the compressed output. The **[keepExif section above](#keepexif)** has the full per-format-per-platform matrix; the short version is:
 
-- PNG/JPEG encoder: System API.
-- WebP encoder:
-  - [SDWebImageWebPCoder](https://github.com/SDWebImage/SDWebImageWebPCoder) on iOS.
-  - System API on Android.
-- HEIF encoder: System API.
-  - [HeifWriter](https://developer.android.com/jetpack/androidx/releases/heifwriter) on Android P+.
+- **iOS + macOS**: full sub-dict passthrough (EXIF, TIFF, GPS, IPTC, PNG chunks) via `CGImageSource → CGImageDestination`. Works for JPEG, PNG, HEIC. Not WebP (ImageIO cannot author WebP metadata).
+- **Android**: ~90-tag copy via `androidx.exifinterface`. Works for JPEG, PNG, WebP. Not HEIC (`ExifInterface` refuses HEIF write; `HeifHandler` logs a warning).
+- **Web + OpenHarmony**: not supported. The Canvas / packing pipelines strip metadata at encode time.
+
+Regardless of platform, the `Orientation` tag is normalized to `1` / `ORIENTATION_NORMAL` on the output — the pipeline bakes rotation into pixels, so preserving the source orientation would cause viewers to double-rotate.
+
+### Encoders in use
+
+- JPEG / PNG: system APIs everywhere.
+- WebP: system API on Android, [SDWebImageWebPCoder](https://github.com/SDWebImage/SDWebImageWebPCoder) on iOS, browser Canvas on Web.
+- HEIC / HEIF: system API on iOS 11+ (ImageIO). Android uses [HeifWriter](https://developer.android.com/jetpack/androidx/releases/heifwriter) on API 28+ (with hardware encoder — falls back to `UnsupportedError` if the device can't produce HEIC).
 
 ## Web
 
 The web implementation is not required for many people,
-
-This plugin uses [pica][] to implement compression.
-
-Currently, [debug mode does not allow you to use the dynamic script loading scheme][flutter-126131].
-And when you actually deploy, you may choose server deployment or cdn deployment, so here we suggest you add script node to head or body by yourself in your `<flutte_project>/web/index.html`.
-
-[flutter-126131]: https://github.com/flutter/flutter/issues/126131
-
-Add for `<flutte_project>/web/index.html`:
-
-```html
-<script src="https://cdn.jsdelivr.net/npm/pica@9.0.1/dist/pica.min.js" ></script>
-
-<!-- or -->
-
-<script src="https://unpkg.com/pica/dist/pica.min.js" ></script>
-```
-
-About web compatibility: two methods with file will throw an exception when used on the web.
-
-[pica]: https://www.npmjs.com/package/pica?activeTab=readme
 
 ## About macOS
 
@@ -388,11 +486,8 @@ Open xcode project, select Runner target, and change the value of `macOS Deploym
 And, change the `Podfile`:
 Change `platform` to `platform :osx, '10.15'`.
 
-
 ## OpenHarmony
 
 The currently supported image formats for parsing include JPEG, PNG, GIF, RAW, WebP, BMP, and SVG. However, the encoding output image formats are currently limited to JPEG, PNG, and WebP only.
 
 当前支持的解析图片格式包括 JPEG、PNG、GIF、RAW、WebP、BMP、SVG . 编码输出图片格式当前仅支持 JPEG、PNG 和 WebP.
-
-

--- a/packages/flutter_image_compress_common/android/build.gradle
+++ b/packages/flutter_image_compress_common/android/build.gradle
@@ -61,7 +61,15 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.exifinterface:exifinterface:1.3.3'
+    // 1.3.7+ fixes several WebP writer bugs relevant to keepExif=true on
+    // WebP output: VP8-only / VP8L-only streams (which Bitmap.compress emits
+    // for lossy/lossless WebP without a VP8X header), corrupted output for
+    // WebP > 8191px, "invalid APP1 marker" writes, and the VP8X E flag not
+    // getting set on the RIFF header so viewers didn't look at the EXIF
+    // chunk. 1.3.3 pre-dates all of these. If bumped, also bump the
+    // KEEP-IN-SYNC copy in the example app: packages/flutter_image_compress/
+    // example/android/app/build.gradle.kts.
+    implementation 'androidx.exifinterface:exifinterface:1.4.2'
     implementation 'androidx.heifwriter:heifwriter:1.0.0'
     implementation 'commons-io:commons-io:2.16.1'
 }

--- a/packages/flutter_image_compress_common/android/src/main/kotlin/com/fluttercandies/flutter_image_compress/handle/common/CommonHandler.kt
+++ b/packages/flutter_image_compress_common/android/src/main/kotlin/com/fluttercandies/flutter_image_compress/handle/common/CommonHandler.kt
@@ -37,14 +37,20 @@ class CommonHandler(override val type: Int) : FormatHandler {
         inSampleSize: Int
     ) {
         val result = compress(byteArray, minWidth, minHeight, quality, rotate, inSampleSize)
-        if (keepExif && bitmapFormat == Bitmap.CompressFormat.JPEG) {
-            val byteArrayOutputStream = ByteArrayOutputStream()
-            byteArrayOutputStream.write(result)
-            val resultStream = ExifKeeper(byteArray).writeToOutputStream(
-                context,
-                byteArrayOutputStream
-            )
-            outputStream.write(resultStream.toByteArray())
+        if (keepExif && supportsExifWrite(bitmapFormat)) {
+            // ExifKeeper writes to a tmp file and opens it via
+            // ExifInterface(path). ExifInterface sniffs the container from
+            // magic bytes, not the tmp filename's extension, so the same
+            // ExifKeeper path works for JPEG, PNG, and WebP outputs.
+            //
+            // If the SOURCE bytes don't carry readable EXIF (corrupt file,
+            // odd container), ExifKeeper's constructor throws IOException.
+            // Fall back to the raw compressed bytes without EXIF — the
+            // whole compression call must never fail just because there
+            // was no source metadata to copy.
+            outputStream.write(runExifKeeperOrRaw(context, result) {
+                ExifKeeper(byteArray)
+            })
         } else {
             outputStream.write(result)
         }
@@ -126,14 +132,11 @@ class CommonHandler(override val type: Int) : FormatHandler {
             } finally {
                 bitmap.recycle()
             }
-            if (keepExif && bitmapFormat == Bitmap.CompressFormat.JPEG) {
-                val byteArrayOutputStream = ByteArrayOutputStream()
-                byteArrayOutputStream.write(array)
-                val tmpOutputStream = ExifKeeper(path).writeToOutputStream(
-                    context,
-                    byteArrayOutputStream
-                )
-                outputStream.write(tmpOutputStream.toByteArray())
+            if (keepExif && supportsExifWrite(bitmapFormat)) {
+                // See handleByteArray for the format-guard rationale.
+                outputStream.write(runExifKeeperOrRaw(context, array) {
+                    ExifKeeper(path)
+                })
             } else {
                 outputStream.write(array)
             }
@@ -152,5 +155,40 @@ class CommonHandler(override val type: Int) : FormatHandler {
                 numberOfRetries - 1
             );
         }
+    }
+
+    // androidx.exifinterface's `saveAttributes()` accepts JPEG, PNG, and
+    // WebP output containers (the underlying error for anything else is
+    // "ExifInterface only supports saving attributes for JPEG, PNG, and
+    // WebP formats"). WebP-writer correctness requires 1.3.7+ (see the
+    // dependency-version comment in flutter_image_compress_common/android/
+    // build.gradle). Enumerating explicitly instead of `!= HEIC` protects
+    // us if Android adds another `Bitmap.CompressFormat` value in a
+    // future SDK — new formats stay ❌ until proven supported.
+    private fun supportsExifWrite(format: Bitmap.CompressFormat): Boolean =
+        format == Bitmap.CompressFormat.JPEG ||
+                format == Bitmap.CompressFormat.PNG ||
+                format == Bitmap.CompressFormat.WEBP
+
+    // ExifKeeper's constructor calls `new ExifInterface(ByteArrayInputStream)`
+    // (or `ExifInterface(String path)`) which throws IOException when the
+    // source is corrupt or a container ExifInterface doesn't understand.
+    // Fall back to the raw compressed bytes without EXIF instead of
+    // propagating the exception — the whole compression call must never
+    // fail just because there was no source metadata to copy.
+    private inline fun runExifKeeperOrRaw(
+        context: Context,
+        raw: ByteArray,
+        makeKeeper: () -> ExifKeeper
+    ): ByteArray {
+        val keeper = try {
+            makeKeeper()
+        } catch (e: Exception) {
+            log("keepExif=true: could not read source EXIF, falling back to raw compressed bytes: $e")
+            return raw
+        }
+        val buffer = ByteArrayOutputStream()
+        buffer.write(raw)
+        return keeper.writeToOutputStream(context, buffer).toByteArray()
     }
 }

--- a/packages/flutter_image_compress_macos/README.md
+++ b/packages/flutter_image_compress_macos/README.md
@@ -92,7 +92,7 @@ There are several ways to use the library api.
 ```dart
 
   // 1. compress file and get Uint8List
-  Future<Uint8List> testCompressFile(File file) async {
+  Future<Uint8List?> testCompressFile(File file) async {
     var result = await FlutterImageCompress.compressWithFile(
       file.absolute.path,
       minWidth: 2300,
@@ -101,12 +101,14 @@ There are several ways to use the library api.
       rotate: 90,
     );
     print(file.lengthSync());
-    print(result.length);
+    if (result != null) {
+      print(result.length);
+    }
     return result;
   }
 
   // 2. compress file and get file.
-  Future<File> testCompressAndGetFile(File file, String targetPath) async {
+  Future<File?> testCompressAndGetFile(File file, String targetPath) async {
     var result = await FlutterImageCompress.compressAndGetFile(
         file.absolute.path, targetPath,
         quality: 88,
@@ -114,13 +116,16 @@ There are several ways to use the library api.
       );
 
     print(file.lengthSync());
-    print(result.lengthSync());
+    if (result != null) {
+      print(await result.length());
+      return File(result.path);
+    }
 
     return result;
   }
 
   // 3. compress asset and get Uint8List.
-  Future<Uint8List> testCompressAsset(String assetName) async {
+  Future<Uint8List?> testCompressAsset(String assetName) async {
     var list = await FlutterImageCompress.compressAssetImage(
       assetName,
       minHeight: 1920,
@@ -254,8 +259,23 @@ If this parameter is true, EXIF information is saved in the compressed result.
 Attention should be paid to the following points:
 
 1. Default value is false.
-2. Even if set to true, the direction attribute is not included.
-3. Only support jpg format, PNG format does not support.
+2. Even if set to true, the `Orientation` tag is normalized to `1`/`ORIENTATION_NORMAL` — the pipeline bakes rotation into pixels, so preserving the source orientation tag would cause viewers to double-rotate.
+3. Support varies by output format **and** platform:
+
+   | Output format | iOS / macOS | Android |
+   | --- | --- | --- |
+   | JPEG | ✅ full sub-dict passthrough (EXIF, TIFF, GPS, IPTC, PNG) | ✅ ~90 EXIF tags via `androidx.exifinterface` |
+   | PNG  | ✅ same passthrough | ✅ ~90 EXIF tags via `androidx.exifinterface` |
+   | WebP | ❌ ImageIO cannot author WebP metadata; output is a valid WebP without EXIF | ✅ ~90 EXIF tags via `androidx.exifinterface` |
+   | HEIC | ✅ same passthrough | ❌ `androidx.exifinterface` refuses HEIF write; the resulting HEIC is valid but has no EXIF. `HeifHandler` logs a clear warning in this case. |
+
+   The rows marked ❌ still return valid image bytes — you just do not get EXIF back. `keepExif: true` never fails the whole compression call.
+
+##### Follow-ups tracked on [#130](https://github.com/fluttercandies/flutter_image_compress/issues/130)
+
+- **iOS WebP + `keepExif`**: `ImageIO` cannot author WebP containers with metadata. Manual VP8X + EXIF chunk splicing via `SDWebImageWebPCoder` would fix this but is not currently implemented.
+- **Android HEIC + `keepExif`**: `androidx.exifinterface` refuses HEIF write across all versions. Manual ISO/IEC 23008-12 metadata box injection (~400 LoC) would fix this but is not currently implemented.
+- **Web / OpenHarmony `keepExif`**: the Canvas / packing pipelines used by these platforms strip metadata at encode time — no in-tree fix path.
 
 ## Result
 
@@ -295,6 +315,101 @@ Future<void> writeToFile(List<int> image, String filePath) {
   return File(filePath).writeAsBytes(image, flush: true);
 }
 ```
+
+## FAQ
+
+### Compressing to a target file size
+
+Both `quality` (0-100 lossy) and `minWidth`/`minHeight` (max output dimensions,
+see below) influence the output size, but neither maps linearly to bytes. If
+you need the output under a specific limit, iterate:
+
+```dart
+Future<Uint8List> compressToUnder(Uint8List src, int limitBytes) async {
+  var quality = 88;
+  var out = src;
+  while (quality > 10) {
+    out = await FlutterImageCompress.compressWithList(
+      src,
+      quality: quality,
+      minWidth: 1920,
+      minHeight: 1920,
+    );
+    if (out.lengthInBytes <= limitBytes) return out;
+    quality -= 10;
+  }
+  return out;
+}
+```
+
+For very small targets, drop `minWidth`/`minHeight` as well when the quality
+loop bottoms out — the biggest byte-count lever is usually pixel count.
+
+### Why is `minWidth`/`minHeight` named that if it acts like a max?
+
+Historical name. In practice they are **aspect-preserving upper bounds** on
+the output: the pipeline scales down (never up) so that both dimensions fit
+inside the given box while keeping the source aspect ratio. So:
+
+- source 4032×3024, `minWidth: 1920, minHeight: 1920` → output around 1920×1440.
+- source 1000×1000, `minWidth: 500, minHeight: 500`   → output 500×500.
+- source 800×600, `minWidth: 1920, minHeight: 1080`   → output 800×600 (no upscale).
+
+If you want strict maximum-dimension bounds and aren't tied to this plugin,
+that's the mental model to keep — the aspect ratio is always preserved
+(never cropped), only the scale is adjusted.
+
+### Compressed image is larger than the original
+
+Two common causes:
+
+- **PNG re-encoded from PNG.** PNG is lossless; re-encoding a PNG rarely
+  makes it smaller unless you also downscale. `quality` doesn't apply to
+  PNG in the underlying encoders — it just runs the same DEFLATE. If your
+  source PNG was already tightly encoded (e.g. by pngcrush), the output
+  can be a few percent larger.
+- **`minWidth`/`minHeight` larger than the source.** The plugin never
+  upscales, but the re-encoding step still runs and can produce a slightly
+  larger JPEG than the input.
+
+If the source is already small enough for your needs, skip compression when
+`src.lengthInBytes` is below your threshold rather than always calling
+through.
+
+### Calling from a background Isolate / `compute()`
+
+Plugin channels don't work in a background isolate unless you initialize
+the binary messenger first. Inside the isolate:
+
+```dart
+BackgroundIsolateBinaryMessenger.ensureInitialized(rootIsolateToken);
+final out = await FlutterImageCompress.compressWithList(bytes, quality: 80);
+```
+
+`rootIsolateToken` must be obtained from the main isolate (via
+`RootIsolateToken.instance!`) and passed into the isolate's arguments.
+
+Without this, you'll see `UnimplementedError` with a message pointing
+back here — that's the platform interface's `UnsupportedFlutterImageCompress`
+fallback firing.
+
+### Which platforms support which formats?
+
+See the platform-features table near the top of this README. Quick reference:
+
+- **JPEG / PNG**: everywhere.
+- **WebP**: Android + iOS + macOS via SDWebImageWebPCoder, Web via browser
+  (quality-support varies).
+- **HEIC / HEIF**: iOS 11+, Android API 28+ with a hardware encoder — falls
+  back to `UnsupportedError` when unavailable. macOS: no.
+
+### How do I clear the temp files the plugin creates?
+
+The `compressAndGetFile` path writes to your `targetPath`. Anything else
+lands in the system cache directory (`context.cacheDir` on Android,
+`NSTemporaryDirectory()` on iOS). Both are OS-managed — call
+`path_provider`'s `getTemporaryDirectory()` and delete its contents
+yourself if you want manual control.
 
 ## Runtime Error
 
@@ -342,42 +457,25 @@ and use a permission plugin to request permission to access SD cards on Android/
 
 ## About EXIF information
 
-Using this library, EXIF information will be removed by default.
+By default (`keepExif: false`, the default), the compressed output carries no source EXIF — only the encoder-injected minimum required by the container (image dimensions, color space).
 
-EXIF information can be retained by setting keepExif to true,
-but not `direction` information.
+With `keepExif: true`, the plugin copies source EXIF onto the compressed output. The **[keepExif section above](#keepexif)** has the full per-format-per-platform matrix; the short version is:
 
-- PNG/JPEG encoder: System API.
-- WebP encoder:
-  - [SDWebImageWebPCoder](https://github.com/SDWebImage/SDWebImageWebPCoder) on iOS.
-  - System API on Android.
-- HEIF encoder: System API.
-  - [HeifWriter](https://developer.android.com/jetpack/androidx/releases/heifwriter) on Android P+.
+- **iOS + macOS**: full sub-dict passthrough (EXIF, TIFF, GPS, IPTC, PNG chunks) via `CGImageSource → CGImageDestination`. Works for JPEG, PNG, HEIC. Not WebP (ImageIO cannot author WebP metadata).
+- **Android**: ~90-tag copy via `androidx.exifinterface`. Works for JPEG, PNG, WebP. Not HEIC (`ExifInterface` refuses HEIF write; `HeifHandler` logs a warning).
+- **Web + OpenHarmony**: not supported. The Canvas / packing pipelines strip metadata at encode time.
+
+Regardless of platform, the `Orientation` tag is normalized to `1` / `ORIENTATION_NORMAL` on the output — the pipeline bakes rotation into pixels, so preserving the source orientation would cause viewers to double-rotate.
+
+### Encoders in use
+
+- JPEG / PNG: system APIs everywhere.
+- WebP: system API on Android, [SDWebImageWebPCoder](https://github.com/SDWebImage/SDWebImageWebPCoder) on iOS, browser Canvas on Web.
+- HEIC / HEIF: system API on iOS 11+ (ImageIO). Android uses [HeifWriter](https://developer.android.com/jetpack/androidx/releases/heifwriter) on API 28+ (with hardware encoder — falls back to `UnsupportedError` if the device can't produce HEIC).
 
 ## Web
 
 The web implementation is not required for many people,
-
-This plugin uses [pica][] to implement compression.
-
-Currently, [debug mode does not allow you to use the dynamic script loading scheme][flutter-126131].
-And when you actually deploy, you may choose server deployment or cdn deployment, so here we suggest you add script node to head or body by yourself in your `<flutte_project>/web/index.html`.
-
-[flutter-126131]: https://github.com/flutter/flutter/issues/126131
-
-Add for `<flutte_project>/web/index.html`:
-
-```html
-<script src="https://cdn.jsdelivr.net/npm/pica@9.0.1/dist/pica.min.js" ></script>
-
-<!-- or -->
-
-<script src="https://unpkg.com/pica/dist/pica.min.js" ></script>
-```
-
-About web compatibility: two methods with file will throw an exception when used on the web.
-
-[pica]: https://www.npmjs.com/package/pica?activeTab=readme
 
 ## About macOS
 
@@ -388,11 +486,8 @@ Open xcode project, select Runner target, and change the value of `macOS Deploym
 And, change the `Podfile`:
 Change `platform` to `platform :osx, '10.15'`.
 
-
 ## OpenHarmony
 
 The currently supported image formats for parsing include JPEG, PNG, GIF, RAW, WebP, BMP, and SVG. However, the encoding output image formats are currently limited to JPEG, PNG, and WebP only.
 
 当前支持的解析图片格式包括 JPEG、PNG、GIF、RAW、WebP、BMP、SVG . 编码输出图片格式当前仅支持 JPEG、PNG 和 WebP.
-
-

--- a/packages/flutter_image_compress_ohos/README.md
+++ b/packages/flutter_image_compress_ohos/README.md
@@ -92,7 +92,7 @@ There are several ways to use the library api.
 ```dart
 
   // 1. compress file and get Uint8List
-  Future<Uint8List> testCompressFile(File file) async {
+  Future<Uint8List?> testCompressFile(File file) async {
     var result = await FlutterImageCompress.compressWithFile(
       file.absolute.path,
       minWidth: 2300,
@@ -101,12 +101,14 @@ There are several ways to use the library api.
       rotate: 90,
     );
     print(file.lengthSync());
-    print(result.length);
+    if (result != null) {
+      print(result.length);
+    }
     return result;
   }
 
   // 2. compress file and get file.
-  Future<File> testCompressAndGetFile(File file, String targetPath) async {
+  Future<File?> testCompressAndGetFile(File file, String targetPath) async {
     var result = await FlutterImageCompress.compressAndGetFile(
         file.absolute.path, targetPath,
         quality: 88,
@@ -114,13 +116,16 @@ There are several ways to use the library api.
       );
 
     print(file.lengthSync());
-    print(result.lengthSync());
+    if (result != null) {
+      print(await result.length());
+      return File(result.path);
+    }
 
     return result;
   }
 
   // 3. compress asset and get Uint8List.
-  Future<Uint8List> testCompressAsset(String assetName) async {
+  Future<Uint8List?> testCompressAsset(String assetName) async {
     var list = await FlutterImageCompress.compressAssetImage(
       assetName,
       minHeight: 1920,
@@ -254,8 +259,23 @@ If this parameter is true, EXIF information is saved in the compressed result.
 Attention should be paid to the following points:
 
 1. Default value is false.
-2. Even if set to true, the direction attribute is not included.
-3. Only support jpg format, PNG format does not support.
+2. Even if set to true, the `Orientation` tag is normalized to `1`/`ORIENTATION_NORMAL` — the pipeline bakes rotation into pixels, so preserving the source orientation tag would cause viewers to double-rotate.
+3. Support varies by output format **and** platform:
+
+   | Output format | iOS / macOS | Android |
+   | --- | --- | --- |
+   | JPEG | ✅ full sub-dict passthrough (EXIF, TIFF, GPS, IPTC, PNG) | ✅ ~90 EXIF tags via `androidx.exifinterface` |
+   | PNG  | ✅ same passthrough | ✅ ~90 EXIF tags via `androidx.exifinterface` |
+   | WebP | ❌ ImageIO cannot author WebP metadata; output is a valid WebP without EXIF | ✅ ~90 EXIF tags via `androidx.exifinterface` |
+   | HEIC | ✅ same passthrough | ❌ `androidx.exifinterface` refuses HEIF write; the resulting HEIC is valid but has no EXIF. `HeifHandler` logs a clear warning in this case. |
+
+   The rows marked ❌ still return valid image bytes — you just do not get EXIF back. `keepExif: true` never fails the whole compression call.
+
+##### Follow-ups tracked on [#130](https://github.com/fluttercandies/flutter_image_compress/issues/130)
+
+- **iOS WebP + `keepExif`**: `ImageIO` cannot author WebP containers with metadata. Manual VP8X + EXIF chunk splicing via `SDWebImageWebPCoder` would fix this but is not currently implemented.
+- **Android HEIC + `keepExif`**: `androidx.exifinterface` refuses HEIF write across all versions. Manual ISO/IEC 23008-12 metadata box injection (~400 LoC) would fix this but is not currently implemented.
+- **Web / OpenHarmony `keepExif`**: the Canvas / packing pipelines used by these platforms strip metadata at encode time — no in-tree fix path.
 
 ## Result
 
@@ -295,6 +315,101 @@ Future<void> writeToFile(List<int> image, String filePath) {
   return File(filePath).writeAsBytes(image, flush: true);
 }
 ```
+
+## FAQ
+
+### Compressing to a target file size
+
+Both `quality` (0-100 lossy) and `minWidth`/`minHeight` (max output dimensions,
+see below) influence the output size, but neither maps linearly to bytes. If
+you need the output under a specific limit, iterate:
+
+```dart
+Future<Uint8List> compressToUnder(Uint8List src, int limitBytes) async {
+  var quality = 88;
+  var out = src;
+  while (quality > 10) {
+    out = await FlutterImageCompress.compressWithList(
+      src,
+      quality: quality,
+      minWidth: 1920,
+      minHeight: 1920,
+    );
+    if (out.lengthInBytes <= limitBytes) return out;
+    quality -= 10;
+  }
+  return out;
+}
+```
+
+For very small targets, drop `minWidth`/`minHeight` as well when the quality
+loop bottoms out — the biggest byte-count lever is usually pixel count.
+
+### Why is `minWidth`/`minHeight` named that if it acts like a max?
+
+Historical name. In practice they are **aspect-preserving upper bounds** on
+the output: the pipeline scales down (never up) so that both dimensions fit
+inside the given box while keeping the source aspect ratio. So:
+
+- source 4032×3024, `minWidth: 1920, minHeight: 1920` → output around 1920×1440.
+- source 1000×1000, `minWidth: 500, minHeight: 500`   → output 500×500.
+- source 800×600, `minWidth: 1920, minHeight: 1080`   → output 800×600 (no upscale).
+
+If you want strict maximum-dimension bounds and aren't tied to this plugin,
+that's the mental model to keep — the aspect ratio is always preserved
+(never cropped), only the scale is adjusted.
+
+### Compressed image is larger than the original
+
+Two common causes:
+
+- **PNG re-encoded from PNG.** PNG is lossless; re-encoding a PNG rarely
+  makes it smaller unless you also downscale. `quality` doesn't apply to
+  PNG in the underlying encoders — it just runs the same DEFLATE. If your
+  source PNG was already tightly encoded (e.g. by pngcrush), the output
+  can be a few percent larger.
+- **`minWidth`/`minHeight` larger than the source.** The plugin never
+  upscales, but the re-encoding step still runs and can produce a slightly
+  larger JPEG than the input.
+
+If the source is already small enough for your needs, skip compression when
+`src.lengthInBytes` is below your threshold rather than always calling
+through.
+
+### Calling from a background Isolate / `compute()`
+
+Plugin channels don't work in a background isolate unless you initialize
+the binary messenger first. Inside the isolate:
+
+```dart
+BackgroundIsolateBinaryMessenger.ensureInitialized(rootIsolateToken);
+final out = await FlutterImageCompress.compressWithList(bytes, quality: 80);
+```
+
+`rootIsolateToken` must be obtained from the main isolate (via
+`RootIsolateToken.instance!`) and passed into the isolate's arguments.
+
+Without this, you'll see `UnimplementedError` with a message pointing
+back here — that's the platform interface's `UnsupportedFlutterImageCompress`
+fallback firing.
+
+### Which platforms support which formats?
+
+See the platform-features table near the top of this README. Quick reference:
+
+- **JPEG / PNG**: everywhere.
+- **WebP**: Android + iOS + macOS via SDWebImageWebPCoder, Web via browser
+  (quality-support varies).
+- **HEIC / HEIF**: iOS 11+, Android API 28+ with a hardware encoder — falls
+  back to `UnsupportedError` when unavailable. macOS: no.
+
+### How do I clear the temp files the plugin creates?
+
+The `compressAndGetFile` path writes to your `targetPath`. Anything else
+lands in the system cache directory (`context.cacheDir` on Android,
+`NSTemporaryDirectory()` on iOS). Both are OS-managed — call
+`path_provider`'s `getTemporaryDirectory()` and delete its contents
+yourself if you want manual control.
 
 ## Runtime Error
 
@@ -342,42 +457,25 @@ and use a permission plugin to request permission to access SD cards on Android/
 
 ## About EXIF information
 
-Using this library, EXIF information will be removed by default.
+By default (`keepExif: false`, the default), the compressed output carries no source EXIF — only the encoder-injected minimum required by the container (image dimensions, color space).
 
-EXIF information can be retained by setting keepExif to true,
-but not `direction` information.
+With `keepExif: true`, the plugin copies source EXIF onto the compressed output. The **[keepExif section above](#keepexif)** has the full per-format-per-platform matrix; the short version is:
 
-- PNG/JPEG encoder: System API.
-- WebP encoder:
-  - [SDWebImageWebPCoder](https://github.com/SDWebImage/SDWebImageWebPCoder) on iOS.
-  - System API on Android.
-- HEIF encoder: System API.
-  - [HeifWriter](https://developer.android.com/jetpack/androidx/releases/heifwriter) on Android P+.
+- **iOS + macOS**: full sub-dict passthrough (EXIF, TIFF, GPS, IPTC, PNG chunks) via `CGImageSource → CGImageDestination`. Works for JPEG, PNG, HEIC. Not WebP (ImageIO cannot author WebP metadata).
+- **Android**: ~90-tag copy via `androidx.exifinterface`. Works for JPEG, PNG, WebP. Not HEIC (`ExifInterface` refuses HEIF write; `HeifHandler` logs a warning).
+- **Web + OpenHarmony**: not supported. The Canvas / packing pipelines strip metadata at encode time.
+
+Regardless of platform, the `Orientation` tag is normalized to `1` / `ORIENTATION_NORMAL` on the output — the pipeline bakes rotation into pixels, so preserving the source orientation would cause viewers to double-rotate.
+
+### Encoders in use
+
+- JPEG / PNG: system APIs everywhere.
+- WebP: system API on Android, [SDWebImageWebPCoder](https://github.com/SDWebImage/SDWebImageWebPCoder) on iOS, browser Canvas on Web.
+- HEIC / HEIF: system API on iOS 11+ (ImageIO). Android uses [HeifWriter](https://developer.android.com/jetpack/androidx/releases/heifwriter) on API 28+ (with hardware encoder — falls back to `UnsupportedError` if the device can't produce HEIC).
 
 ## Web
 
 The web implementation is not required for many people,
-
-This plugin uses [pica][] to implement compression.
-
-Currently, [debug mode does not allow you to use the dynamic script loading scheme][flutter-126131].
-And when you actually deploy, you may choose server deployment or cdn deployment, so here we suggest you add script node to head or body by yourself in your `<flutte_project>/web/index.html`.
-
-[flutter-126131]: https://github.com/flutter/flutter/issues/126131
-
-Add for `<flutte_project>/web/index.html`:
-
-```html
-<script src="https://cdn.jsdelivr.net/npm/pica@9.0.1/dist/pica.min.js" ></script>
-
-<!-- or -->
-
-<script src="https://unpkg.com/pica/dist/pica.min.js" ></script>
-```
-
-About web compatibility: two methods with file will throw an exception when used on the web.
-
-[pica]: https://www.npmjs.com/package/pica?activeTab=readme
 
 ## About macOS
 
@@ -388,11 +486,8 @@ Open xcode project, select Runner target, and change the value of `macOS Deploym
 And, change the `Podfile`:
 Change `platform` to `platform :osx, '10.15'`.
 
-
 ## OpenHarmony
 
 The currently supported image formats for parsing include JPEG, PNG, GIF, RAW, WebP, BMP, and SVG. However, the encoding output image formats are currently limited to JPEG, PNG, and WebP only.
 
 当前支持的解析图片格式包括 JPEG、PNG、GIF、RAW、WebP、BMP、SVG . 编码输出图片格式当前仅支持 JPEG、PNG 和 WebP.
-
-

--- a/packages/flutter_image_compress_platform_interface/README.md
+++ b/packages/flutter_image_compress_platform_interface/README.md
@@ -92,7 +92,7 @@ There are several ways to use the library api.
 ```dart
 
   // 1. compress file and get Uint8List
-  Future<Uint8List> testCompressFile(File file) async {
+  Future<Uint8List?> testCompressFile(File file) async {
     var result = await FlutterImageCompress.compressWithFile(
       file.absolute.path,
       minWidth: 2300,
@@ -101,12 +101,14 @@ There are several ways to use the library api.
       rotate: 90,
     );
     print(file.lengthSync());
-    print(result.length);
+    if (result != null) {
+      print(result.length);
+    }
     return result;
   }
 
   // 2. compress file and get file.
-  Future<File> testCompressAndGetFile(File file, String targetPath) async {
+  Future<File?> testCompressAndGetFile(File file, String targetPath) async {
     var result = await FlutterImageCompress.compressAndGetFile(
         file.absolute.path, targetPath,
         quality: 88,
@@ -114,13 +116,16 @@ There are several ways to use the library api.
       );
 
     print(file.lengthSync());
-    print(result.lengthSync());
+    if (result != null) {
+      print(await result.length());
+      return File(result.path);
+    }
 
     return result;
   }
 
   // 3. compress asset and get Uint8List.
-  Future<Uint8List> testCompressAsset(String assetName) async {
+  Future<Uint8List?> testCompressAsset(String assetName) async {
     var list = await FlutterImageCompress.compressAssetImage(
       assetName,
       minHeight: 1920,
@@ -254,8 +259,23 @@ If this parameter is true, EXIF information is saved in the compressed result.
 Attention should be paid to the following points:
 
 1. Default value is false.
-2. Even if set to true, the direction attribute is not included.
-3. Only support jpg format, PNG format does not support.
+2. Even if set to true, the `Orientation` tag is normalized to `1`/`ORIENTATION_NORMAL` — the pipeline bakes rotation into pixels, so preserving the source orientation tag would cause viewers to double-rotate.
+3. Support varies by output format **and** platform:
+
+   | Output format | iOS / macOS | Android |
+   | --- | --- | --- |
+   | JPEG | ✅ full sub-dict passthrough (EXIF, TIFF, GPS, IPTC, PNG) | ✅ ~90 EXIF tags via `androidx.exifinterface` |
+   | PNG  | ✅ same passthrough | ✅ ~90 EXIF tags via `androidx.exifinterface` |
+   | WebP | ❌ ImageIO cannot author WebP metadata; output is a valid WebP without EXIF | ✅ ~90 EXIF tags via `androidx.exifinterface` |
+   | HEIC | ✅ same passthrough | ❌ `androidx.exifinterface` refuses HEIF write; the resulting HEIC is valid but has no EXIF. `HeifHandler` logs a clear warning in this case. |
+
+   The rows marked ❌ still return valid image bytes — you just do not get EXIF back. `keepExif: true` never fails the whole compression call.
+
+##### Follow-ups tracked on [#130](https://github.com/fluttercandies/flutter_image_compress/issues/130)
+
+- **iOS WebP + `keepExif`**: `ImageIO` cannot author WebP containers with metadata. Manual VP8X + EXIF chunk splicing via `SDWebImageWebPCoder` would fix this but is not currently implemented.
+- **Android HEIC + `keepExif`**: `androidx.exifinterface` refuses HEIF write across all versions. Manual ISO/IEC 23008-12 metadata box injection (~400 LoC) would fix this but is not currently implemented.
+- **Web / OpenHarmony `keepExif`**: the Canvas / packing pipelines used by these platforms strip metadata at encode time — no in-tree fix path.
 
 ## Result
 
@@ -295,6 +315,101 @@ Future<void> writeToFile(List<int> image, String filePath) {
   return File(filePath).writeAsBytes(image, flush: true);
 }
 ```
+
+## FAQ
+
+### Compressing to a target file size
+
+Both `quality` (0-100 lossy) and `minWidth`/`minHeight` (max output dimensions,
+see below) influence the output size, but neither maps linearly to bytes. If
+you need the output under a specific limit, iterate:
+
+```dart
+Future<Uint8List> compressToUnder(Uint8List src, int limitBytes) async {
+  var quality = 88;
+  var out = src;
+  while (quality > 10) {
+    out = await FlutterImageCompress.compressWithList(
+      src,
+      quality: quality,
+      minWidth: 1920,
+      minHeight: 1920,
+    );
+    if (out.lengthInBytes <= limitBytes) return out;
+    quality -= 10;
+  }
+  return out;
+}
+```
+
+For very small targets, drop `minWidth`/`minHeight` as well when the quality
+loop bottoms out — the biggest byte-count lever is usually pixel count.
+
+### Why is `minWidth`/`minHeight` named that if it acts like a max?
+
+Historical name. In practice they are **aspect-preserving upper bounds** on
+the output: the pipeline scales down (never up) so that both dimensions fit
+inside the given box while keeping the source aspect ratio. So:
+
+- source 4032×3024, `minWidth: 1920, minHeight: 1920` → output around 1920×1440.
+- source 1000×1000, `minWidth: 500, minHeight: 500`   → output 500×500.
+- source 800×600, `minWidth: 1920, minHeight: 1080`   → output 800×600 (no upscale).
+
+If you want strict maximum-dimension bounds and aren't tied to this plugin,
+that's the mental model to keep — the aspect ratio is always preserved
+(never cropped), only the scale is adjusted.
+
+### Compressed image is larger than the original
+
+Two common causes:
+
+- **PNG re-encoded from PNG.** PNG is lossless; re-encoding a PNG rarely
+  makes it smaller unless you also downscale. `quality` doesn't apply to
+  PNG in the underlying encoders — it just runs the same DEFLATE. If your
+  source PNG was already tightly encoded (e.g. by pngcrush), the output
+  can be a few percent larger.
+- **`minWidth`/`minHeight` larger than the source.** The plugin never
+  upscales, but the re-encoding step still runs and can produce a slightly
+  larger JPEG than the input.
+
+If the source is already small enough for your needs, skip compression when
+`src.lengthInBytes` is below your threshold rather than always calling
+through.
+
+### Calling from a background Isolate / `compute()`
+
+Plugin channels don't work in a background isolate unless you initialize
+the binary messenger first. Inside the isolate:
+
+```dart
+BackgroundIsolateBinaryMessenger.ensureInitialized(rootIsolateToken);
+final out = await FlutterImageCompress.compressWithList(bytes, quality: 80);
+```
+
+`rootIsolateToken` must be obtained from the main isolate (via
+`RootIsolateToken.instance!`) and passed into the isolate's arguments.
+
+Without this, you'll see `UnimplementedError` with a message pointing
+back here — that's the platform interface's `UnsupportedFlutterImageCompress`
+fallback firing.
+
+### Which platforms support which formats?
+
+See the platform-features table near the top of this README. Quick reference:
+
+- **JPEG / PNG**: everywhere.
+- **WebP**: Android + iOS + macOS via SDWebImageWebPCoder, Web via browser
+  (quality-support varies).
+- **HEIC / HEIF**: iOS 11+, Android API 28+ with a hardware encoder — falls
+  back to `UnsupportedError` when unavailable. macOS: no.
+
+### How do I clear the temp files the plugin creates?
+
+The `compressAndGetFile` path writes to your `targetPath`. Anything else
+lands in the system cache directory (`context.cacheDir` on Android,
+`NSTemporaryDirectory()` on iOS). Both are OS-managed — call
+`path_provider`'s `getTemporaryDirectory()` and delete its contents
+yourself if you want manual control.
 
 ## Runtime Error
 
@@ -342,42 +457,25 @@ and use a permission plugin to request permission to access SD cards on Android/
 
 ## About EXIF information
 
-Using this library, EXIF information will be removed by default.
+By default (`keepExif: false`, the default), the compressed output carries no source EXIF — only the encoder-injected minimum required by the container (image dimensions, color space).
 
-EXIF information can be retained by setting keepExif to true,
-but not `direction` information.
+With `keepExif: true`, the plugin copies source EXIF onto the compressed output. The **[keepExif section above](#keepexif)** has the full per-format-per-platform matrix; the short version is:
 
-- PNG/JPEG encoder: System API.
-- WebP encoder:
-  - [SDWebImageWebPCoder](https://github.com/SDWebImage/SDWebImageWebPCoder) on iOS.
-  - System API on Android.
-- HEIF encoder: System API.
-  - [HeifWriter](https://developer.android.com/jetpack/androidx/releases/heifwriter) on Android P+.
+- **iOS + macOS**: full sub-dict passthrough (EXIF, TIFF, GPS, IPTC, PNG chunks) via `CGImageSource → CGImageDestination`. Works for JPEG, PNG, HEIC. Not WebP (ImageIO cannot author WebP metadata).
+- **Android**: ~90-tag copy via `androidx.exifinterface`. Works for JPEG, PNG, WebP. Not HEIC (`ExifInterface` refuses HEIF write; `HeifHandler` logs a warning).
+- **Web + OpenHarmony**: not supported. The Canvas / packing pipelines strip metadata at encode time.
+
+Regardless of platform, the `Orientation` tag is normalized to `1` / `ORIENTATION_NORMAL` on the output — the pipeline bakes rotation into pixels, so preserving the source orientation would cause viewers to double-rotate.
+
+### Encoders in use
+
+- JPEG / PNG: system APIs everywhere.
+- WebP: system API on Android, [SDWebImageWebPCoder](https://github.com/SDWebImage/SDWebImageWebPCoder) on iOS, browser Canvas on Web.
+- HEIC / HEIF: system API on iOS 11+ (ImageIO). Android uses [HeifWriter](https://developer.android.com/jetpack/androidx/releases/heifwriter) on API 28+ (with hardware encoder — falls back to `UnsupportedError` if the device can't produce HEIC).
 
 ## Web
 
 The web implementation is not required for many people,
-
-This plugin uses [pica][] to implement compression.
-
-Currently, [debug mode does not allow you to use the dynamic script loading scheme][flutter-126131].
-And when you actually deploy, you may choose server deployment or cdn deployment, so here we suggest you add script node to head or body by yourself in your `<flutte_project>/web/index.html`.
-
-[flutter-126131]: https://github.com/flutter/flutter/issues/126131
-
-Add for `<flutte_project>/web/index.html`:
-
-```html
-<script src="https://cdn.jsdelivr.net/npm/pica@9.0.1/dist/pica.min.js" ></script>
-
-<!-- or -->
-
-<script src="https://unpkg.com/pica/dist/pica.min.js" ></script>
-```
-
-About web compatibility: two methods with file will throw an exception when used on the web.
-
-[pica]: https://www.npmjs.com/package/pica?activeTab=readme
 
 ## About macOS
 
@@ -388,11 +486,8 @@ Open xcode project, select Runner target, and change the value of `macOS Deploym
 And, change the `Podfile`:
 Change `platform` to `platform :osx, '10.15'`.
 
-
 ## OpenHarmony
 
 The currently supported image formats for parsing include JPEG, PNG, GIF, RAW, WebP, BMP, and SVG. However, the encoding output image formats are currently limited to JPEG, PNG, and WebP only.
 
 当前支持的解析图片格式包括 JPEG、PNG、GIF、RAW、WebP、BMP、SVG . 编码输出图片格式当前仅支持 JPEG、PNG 和 WebP.
-
-

--- a/packages/flutter_image_compress_web/README.md
+++ b/packages/flutter_image_compress_web/README.md
@@ -92,7 +92,7 @@ There are several ways to use the library api.
 ```dart
 
   // 1. compress file and get Uint8List
-  Future<Uint8List> testCompressFile(File file) async {
+  Future<Uint8List?> testCompressFile(File file) async {
     var result = await FlutterImageCompress.compressWithFile(
       file.absolute.path,
       minWidth: 2300,
@@ -101,12 +101,14 @@ There are several ways to use the library api.
       rotate: 90,
     );
     print(file.lengthSync());
-    print(result.length);
+    if (result != null) {
+      print(result.length);
+    }
     return result;
   }
 
   // 2. compress file and get file.
-  Future<File> testCompressAndGetFile(File file, String targetPath) async {
+  Future<File?> testCompressAndGetFile(File file, String targetPath) async {
     var result = await FlutterImageCompress.compressAndGetFile(
         file.absolute.path, targetPath,
         quality: 88,
@@ -114,13 +116,16 @@ There are several ways to use the library api.
       );
 
     print(file.lengthSync());
-    print(result.lengthSync());
+    if (result != null) {
+      print(await result.length());
+      return File(result.path);
+    }
 
     return result;
   }
 
   // 3. compress asset and get Uint8List.
-  Future<Uint8List> testCompressAsset(String assetName) async {
+  Future<Uint8List?> testCompressAsset(String assetName) async {
     var list = await FlutterImageCompress.compressAssetImage(
       assetName,
       minHeight: 1920,
@@ -254,8 +259,23 @@ If this parameter is true, EXIF information is saved in the compressed result.
 Attention should be paid to the following points:
 
 1. Default value is false.
-2. Even if set to true, the direction attribute is not included.
-3. Only support jpg format, PNG format does not support.
+2. Even if set to true, the `Orientation` tag is normalized to `1`/`ORIENTATION_NORMAL` — the pipeline bakes rotation into pixels, so preserving the source orientation tag would cause viewers to double-rotate.
+3. Support varies by output format **and** platform:
+
+   | Output format | iOS / macOS | Android |
+   | --- | --- | --- |
+   | JPEG | ✅ full sub-dict passthrough (EXIF, TIFF, GPS, IPTC, PNG) | ✅ ~90 EXIF tags via `androidx.exifinterface` |
+   | PNG  | ✅ same passthrough | ✅ ~90 EXIF tags via `androidx.exifinterface` |
+   | WebP | ❌ ImageIO cannot author WebP metadata; output is a valid WebP without EXIF | ✅ ~90 EXIF tags via `androidx.exifinterface` |
+   | HEIC | ✅ same passthrough | ❌ `androidx.exifinterface` refuses HEIF write; the resulting HEIC is valid but has no EXIF. `HeifHandler` logs a clear warning in this case. |
+
+   The rows marked ❌ still return valid image bytes — you just do not get EXIF back. `keepExif: true` never fails the whole compression call.
+
+##### Follow-ups tracked on [#130](https://github.com/fluttercandies/flutter_image_compress/issues/130)
+
+- **iOS WebP + `keepExif`**: `ImageIO` cannot author WebP containers with metadata. Manual VP8X + EXIF chunk splicing via `SDWebImageWebPCoder` would fix this but is not currently implemented.
+- **Android HEIC + `keepExif`**: `androidx.exifinterface` refuses HEIF write across all versions. Manual ISO/IEC 23008-12 metadata box injection (~400 LoC) would fix this but is not currently implemented.
+- **Web / OpenHarmony `keepExif`**: the Canvas / packing pipelines used by these platforms strip metadata at encode time — no in-tree fix path.
 
 ## Result
 
@@ -295,6 +315,101 @@ Future<void> writeToFile(List<int> image, String filePath) {
   return File(filePath).writeAsBytes(image, flush: true);
 }
 ```
+
+## FAQ
+
+### Compressing to a target file size
+
+Both `quality` (0-100 lossy) and `minWidth`/`minHeight` (max output dimensions,
+see below) influence the output size, but neither maps linearly to bytes. If
+you need the output under a specific limit, iterate:
+
+```dart
+Future<Uint8List> compressToUnder(Uint8List src, int limitBytes) async {
+  var quality = 88;
+  var out = src;
+  while (quality > 10) {
+    out = await FlutterImageCompress.compressWithList(
+      src,
+      quality: quality,
+      minWidth: 1920,
+      minHeight: 1920,
+    );
+    if (out.lengthInBytes <= limitBytes) return out;
+    quality -= 10;
+  }
+  return out;
+}
+```
+
+For very small targets, drop `minWidth`/`minHeight` as well when the quality
+loop bottoms out — the biggest byte-count lever is usually pixel count.
+
+### Why is `minWidth`/`minHeight` named that if it acts like a max?
+
+Historical name. In practice they are **aspect-preserving upper bounds** on
+the output: the pipeline scales down (never up) so that both dimensions fit
+inside the given box while keeping the source aspect ratio. So:
+
+- source 4032×3024, `minWidth: 1920, minHeight: 1920` → output around 1920×1440.
+- source 1000×1000, `minWidth: 500, minHeight: 500`   → output 500×500.
+- source 800×600, `minWidth: 1920, minHeight: 1080`   → output 800×600 (no upscale).
+
+If you want strict maximum-dimension bounds and aren't tied to this plugin,
+that's the mental model to keep — the aspect ratio is always preserved
+(never cropped), only the scale is adjusted.
+
+### Compressed image is larger than the original
+
+Two common causes:
+
+- **PNG re-encoded from PNG.** PNG is lossless; re-encoding a PNG rarely
+  makes it smaller unless you also downscale. `quality` doesn't apply to
+  PNG in the underlying encoders — it just runs the same DEFLATE. If your
+  source PNG was already tightly encoded (e.g. by pngcrush), the output
+  can be a few percent larger.
+- **`minWidth`/`minHeight` larger than the source.** The plugin never
+  upscales, but the re-encoding step still runs and can produce a slightly
+  larger JPEG than the input.
+
+If the source is already small enough for your needs, skip compression when
+`src.lengthInBytes` is below your threshold rather than always calling
+through.
+
+### Calling from a background Isolate / `compute()`
+
+Plugin channels don't work in a background isolate unless you initialize
+the binary messenger first. Inside the isolate:
+
+```dart
+BackgroundIsolateBinaryMessenger.ensureInitialized(rootIsolateToken);
+final out = await FlutterImageCompress.compressWithList(bytes, quality: 80);
+```
+
+`rootIsolateToken` must be obtained from the main isolate (via
+`RootIsolateToken.instance!`) and passed into the isolate's arguments.
+
+Without this, you'll see `UnimplementedError` with a message pointing
+back here — that's the platform interface's `UnsupportedFlutterImageCompress`
+fallback firing.
+
+### Which platforms support which formats?
+
+See the platform-features table near the top of this README. Quick reference:
+
+- **JPEG / PNG**: everywhere.
+- **WebP**: Android + iOS + macOS via SDWebImageWebPCoder, Web via browser
+  (quality-support varies).
+- **HEIC / HEIF**: iOS 11+, Android API 28+ with a hardware encoder — falls
+  back to `UnsupportedError` when unavailable. macOS: no.
+
+### How do I clear the temp files the plugin creates?
+
+The `compressAndGetFile` path writes to your `targetPath`. Anything else
+lands in the system cache directory (`context.cacheDir` on Android,
+`NSTemporaryDirectory()` on iOS). Both are OS-managed — call
+`path_provider`'s `getTemporaryDirectory()` and delete its contents
+yourself if you want manual control.
 
 ## Runtime Error
 
@@ -342,42 +457,25 @@ and use a permission plugin to request permission to access SD cards on Android/
 
 ## About EXIF information
 
-Using this library, EXIF information will be removed by default.
+By default (`keepExif: false`, the default), the compressed output carries no source EXIF — only the encoder-injected minimum required by the container (image dimensions, color space).
 
-EXIF information can be retained by setting keepExif to true,
-but not `direction` information.
+With `keepExif: true`, the plugin copies source EXIF onto the compressed output. The **[keepExif section above](#keepexif)** has the full per-format-per-platform matrix; the short version is:
 
-- PNG/JPEG encoder: System API.
-- WebP encoder:
-  - [SDWebImageWebPCoder](https://github.com/SDWebImage/SDWebImageWebPCoder) on iOS.
-  - System API on Android.
-- HEIF encoder: System API.
-  - [HeifWriter](https://developer.android.com/jetpack/androidx/releases/heifwriter) on Android P+.
+- **iOS + macOS**: full sub-dict passthrough (EXIF, TIFF, GPS, IPTC, PNG chunks) via `CGImageSource → CGImageDestination`. Works for JPEG, PNG, HEIC. Not WebP (ImageIO cannot author WebP metadata).
+- **Android**: ~90-tag copy via `androidx.exifinterface`. Works for JPEG, PNG, WebP. Not HEIC (`ExifInterface` refuses HEIF write; `HeifHandler` logs a warning).
+- **Web + OpenHarmony**: not supported. The Canvas / packing pipelines strip metadata at encode time.
+
+Regardless of platform, the `Orientation` tag is normalized to `1` / `ORIENTATION_NORMAL` on the output — the pipeline bakes rotation into pixels, so preserving the source orientation would cause viewers to double-rotate.
+
+### Encoders in use
+
+- JPEG / PNG: system APIs everywhere.
+- WebP: system API on Android, [SDWebImageWebPCoder](https://github.com/SDWebImage/SDWebImageWebPCoder) on iOS, browser Canvas on Web.
+- HEIC / HEIF: system API on iOS 11+ (ImageIO). Android uses [HeifWriter](https://developer.android.com/jetpack/androidx/releases/heifwriter) on API 28+ (with hardware encoder — falls back to `UnsupportedError` if the device can't produce HEIC).
 
 ## Web
 
 The web implementation is not required for many people,
-
-This plugin uses [pica][] to implement compression.
-
-Currently, [debug mode does not allow you to use the dynamic script loading scheme][flutter-126131].
-And when you actually deploy, you may choose server deployment or cdn deployment, so here we suggest you add script node to head or body by yourself in your `<flutte_project>/web/index.html`.
-
-[flutter-126131]: https://github.com/flutter/flutter/issues/126131
-
-Add for `<flutte_project>/web/index.html`:
-
-```html
-<script src="https://cdn.jsdelivr.net/npm/pica@9.0.1/dist/pica.min.js" ></script>
-
-<!-- or -->
-
-<script src="https://unpkg.com/pica/dist/pica.min.js" ></script>
-```
-
-About web compatibility: two methods with file will throw an exception when used on the web.
-
-[pica]: https://www.npmjs.com/package/pica?activeTab=readme
 
 ## About macOS
 
@@ -388,11 +486,8 @@ Open xcode project, select Runner target, and change the value of `macOS Deploym
 And, change the `Podfile`:
 Change `platform` to `platform :osx, '10.15'`.
 
-
 ## OpenHarmony
 
 The currently supported image formats for parsing include JPEG, PNG, GIF, RAW, WebP, BMP, and SVG. However, the encoding output image formats are currently limited to JPEG, PNG, and WebP only.
 
 当前支持的解析图片格式包括 JPEG、PNG、GIF、RAW、WebP、BMP、SVG . 编码输出图片格式当前仅支持 JPEG、PNG 和 WebP.
-
-


### PR DESCRIPTION
Second follow-up to **#130** (following #394 for the HEIC docs surface).

Stacked on top of `fix/android-heic-keep-exif` (PR #394) since that PR adds the shared Android test-helper channel this one uses; merge order is #394 → this. GitHub will retarget to `main` once #394 lands.

## Bug

`CommonHandler` on Android short-circuits `ExifKeeper` unless the output is JPEG:

\`\`\`kotlin
if (keepExif && bitmapFormat == Bitmap.CompressFormat.JPEG) { … }
\`\`\`

PNG and WebP output silently drop source EXIF regardless of `keepExif: true`.

## Fix

- Replace the JPEG-only guard with `supportsExifWrite(format)` — a private helper that whitelists JPEG, PNG, WebP (the exact three formats `androidx.exifinterface.saveAttributes()` supports; disassembly confirms it throws for anything else).
- Bump `androidx.exifinterface` **1.3.3 → 1.4.2** in both `flutter_image_compress_common/android/build.gradle` and the example app's `build.gradle.kts` (KEEP-IN-SYNC comment). 1.3.3 predates critical WebP writer fixes:
  - VP8 / VP8L-only WebP streams — what `Bitmap.compress(WEBP, quality)` emits without a VP8X chunk — weren't accepted before ~1.3.7.
  - `> 8191px` WebP output corrupted before the same era.
  - VP8X `E` flag wasn't set on the RIFF header, so downstream readers didn't look at the EXIF chunk we just wrote.
- New `runExifKeeperOrRaw` helper: if the source doesn't have readable EXIF (`ExifKeeper` constructor throws), fall back to the raw compressed bytes with a log line rather than propagating up to the handler and returning `null` for the whole call. `keepExif=true` degrades gracefully to \"compressed but no EXIF\".

## Verification

Two new integration tests on Android using the test-helper channel from #394:

- `Android PNG + keepExif=true`: asserts `exif:DateTimeOriginal`, `exif:DateTimeDigitized`, `tiff:DateTime` from `auto-angle.jpg` all survive in PNG output.
- `Android WebP + keepExif=true`: same assertion for WebP output.

Both pass on Android emulator (API 36, exifinterface 1.4.2). Verified iOS still passes — Android-only tests skip cleanly, existing iOS/macOS keepExif assertions unchanged.

## README

The per-format keepExif matrix flips Android PNG and WebP from ❌ to ✅. The follow-ups section now enumerates only the two remaining gaps still tracked under #130:

- **iOS WebP**: ImageIO cannot author WebP metadata (unchanged from before).
- **Android HEIC**: `androidx.exifinterface` refuses HEIF write (addressed as docs-only in #394).

## Adversarial review

Subagent flagged: `exifinterface 1.3.3` predates VP8/VP8L / 8191px / VP8X-E-flag WebP writer fixes (**FIXED** via 1.4.2 bump); double `saveAttributes()` inside `ExifKeeper` doubles WebP corruption blast radius on old versions (**MITIGATED** by version bump); source-parse throw becomes user-visible `null` return for weird source containers (**FIXED** via `runExifKeeperOrRaw` fallback); misleading `1.3.3+` comment (**FIXED**).

## Test plan

- [x] `melos run format`
- [x] `melos run analyze`
- [x] Android emulator (API 36): 7/7 keepExif tests pass including the 2 new PNG/WebP regression tests
- [x] iOS 26.5 simulator: 5/5 keepExif tests pass, 2 Android-only tests skip cleanly
- [x] Adversarial subagent review of the delta only — 4 real defects caught and fixed
- [x] CI: iOS/macOS both integration flavors, Android build, Web build

Refs #130.

🤖 Generated with [Claude Code](https://claude.com/claude-code)