### PR TITLE
fix(macOS): offload compression off the AppKit main thread

### DIFF
--- a/packages/flutter_image_compress_macos/macos/.gitignore
+++ b/packages/flutter_image_compress_macos/macos/.gitignore
@@ -1,1 +1,2 @@
 Flutter/
+.build/

--- a/packages/flutter_image_compress_macos/macos/flutter_image_compress_macos/Sources/flutter_image_compress_macos/FlutterImageCompressMacosPlugin.swift
+++ b/packages/flutter_image_compress_macos/macos/flutter_image_compress_macos/Sources/flutter_image_compress_macos/FlutterImageCompressMacosPlugin.swift
@@ -138,21 +138,51 @@ public class FlutterImageCompressMacosPlugin: NSObject, FlutterPlugin {
     let method = call.method
     let args = call.arguments
 
-    switch method {
-    case "showLog":
+    // showLog is a fast setter — reply on the calling thread and skip the
+    // background hop. Every branch of handle(...) must resolve `result`,
+    // otherwise the awaiting Dart future hangs forever.
+    if method == "showLog" {
       Logger.showLog(show: args as! Bool)
-    case "compressAndGetFile":
-      let dstPath = (args as! Dictionary<String, Any>)["targetPath"] as! String
-      handleResult(args, result)?.compressToPath(result, dstPath)
-      break
-    case "compressWithFile":
-      handleResult(args, result)?.compressToBytes(result)
-      break
-    case "compressWithList":
-      handleResult(args, result)?.compressToBytes(result)
-      break
-    default:
-      result(FlutterMethodNotImplemented)
+      result(1)
+      return
+    }
+
+    // Compression (decode / CGContext resize+rotate / CGImageDestination
+    // encode / disk write) is CPU- and I/O-heavy. FlutterMethodChannel
+    // dispatches on the AppKit main thread, so running the work inline
+    // stalls Flutter's UI. Offload to a background queue and marshal the
+    // FlutterResult back to the platform thread — same pattern as the
+    // Android threadPool + main-Looper Handler and iOS global-queue
+    // handlers.
+    let mainResult: FlutterResult = { value in
+      if Thread.isMainThread {
+        result(value)
+      } else {
+        DispatchQueue.main.async { result(value) }
+      }
+    }
+
+    DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+      guard let self = self else {
+        // Plugin was detached before we got scheduled. Reply anyway so the
+        // Dart future doesn't hang; the engine tolerates result(...) on a
+        // torn-down channel.
+        mainResult(FlutterError(code: "plugin_detached",
+                                message: "Plugin was detached before compression could start",
+                                details: nil))
+        return
+      }
+      switch method {
+      case "compressAndGetFile":
+        let dstPath = (args as! Dictionary<String, Any>)["targetPath"] as! String
+        self.handleResult(args, mainResult)?.compressToPath(mainResult, dstPath)
+      case "compressWithFile":
+        self.handleResult(args, mainResult)?.compressToBytes(mainResult)
+      case "compressWithList":
+        self.handleResult(args, mainResult)?.compressToBytes(mainResult)
+      default:
+        mainResult(FlutterMethodNotImplemented)
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

`FlutterMethodChannel` dispatches `handle(_:result:)` on the platform thread — on macOS that's the AppKit main / UI thread. The plugin ran decode, `CGContext` resize+rotate, `CGImageDestination` encode and disk writes inline on that thread, so compressing anything nontrivial stalled the Flutter engine and froze the UI (dropped frames, gesture/input hangs, animation stutter).

Android and iOS already offload:

- **Android** — every compress method is `threadPool.execute { … }` on a fixed 8-thread `ExecutorService`, with results posted back via `Handler(Looper.getMainLooper())` ([`ResultHandler.kt`](https://github.com/fluttercandies/flutter_image_compress/blob/main/packages/flutter_image_compress_common/android/src/main/kotlin/com/fluttercandies/flutter_image_compress/core/ResultHandler.kt#L15)).
- **iOS** — `ImageCompressPlugin.handleMethodCall:` wraps the switch in `dispatch_async(dispatch_get_global_queue(0, 0), …)` ([`ImageCompressPlugin.m`](https://github.com/fluttercandies/flutter_image_compress/blob/main/packages/flutter_image_compress_common/ios/flutter_image_compress_common/Sources/flutter_image_compress_common/ImageCompressPlugin.m#L11-L21)).

macOS now matches: compression runs on `DispatchQueue.global(qos: .userInitiated)`, `FlutterResult` is marshaled back to the main thread via a small `mainResult` shim.

## What changed

`FlutterImageCompressMacosPlugin.swift` — `handle(_:result:)` only:

1. **Threading** — the three compress branches (`compressAndGetFile`, `compressWithFile`, `compressWithList`) plus `default` (`FlutterMethodNotImplemented`) run inside `DispatchQueue.global(qos: .userInitiated).async { … }`.
2. **`mainResult` shim** — wraps `FlutterResult` so every downstream callback (`handleResult`'s error paths at lines 108/124/132, `Compressor.compressToPath` / `compressToBytes` at lines 402/423) always resolves on the main thread regardless of where it's invoked from.
3. **`showLog` reply gap** — the previous switch case was `Logger.showLog(show: args as! Bool)` with no `result(…)` call, leaving the awaiting Dart future pending. Now returns `1` to match Android (`result.success(1)`) and iOS (`result(@1)`). Kept synchronous on the calling thread — it's a fast setter, no reason to hop.
4. **`[weak self]` nil branch** — if the plugin is detached before the async block starts, previously the `guard let self else { return }` swallowed the call silently. Now replies with `FlutterError(code: "plugin_detached", …)` so the Dart future always resolves.

Also updates `packages/flutter_image_compress_macos/macos/.gitignore` to ignore SwiftPM's `.build/` output that IDE indexing / `swift build` leaves under `macos/flutter_image_compress_macos/`.

## Test plan

- [x] `flutter build macos --debug` from the example — clean.
- [x] `flutter test integration_test/compress_test.dart -d macos` — all 13 macOS-relevant tests pass (7 skipped are Android/iOS-only), including HEIC round-trip, EXIF preservation across JPEG/PNG/HEIC, rotate 90/180/270, transparent PNG, WebP interop.
- [ ] Reviewer manual UI-freeze repro (optional): before this PR, compressing a ~20MB image on macOS visibly hitches Flutter animations for the duration of the compress; after this PR, animations run smoothly and the compress just resolves out of band.

## Notes for melos changelog

Single `fix(macOS): …` commit — will land under `flutter_image_compress_macos`'s Bug Fixes section.