### PR TITLE
fix(Android): handle Gradle 9 Kotlin modes safely

### DIFF
--- a/.github/fixtures/kotlin_mode/.gitignore
+++ b/.github/fixtures/kotlin_mode/.gitignore
@@ -1,0 +1,2 @@
+.gradle/
+build/

--- a/.github/fixtures/kotlin_mode/built_in_default/build.gradle
+++ b/.github/fixtures/kotlin_mode/built_in_default/build.gradle
@@ -1,0 +1,3 @@
+plugins {
+    id "com.android.library" version "9.2.1" apply false
+}

--- a/.github/fixtures/kotlin_mode/built_in_default/gradle.properties
+++ b/.github/fixtures/kotlin_mode/built_in_default/gradle.properties
@@ -1,0 +1,2 @@
+android.newDsl=false
+org.gradle.jvmargs=-Xmx1536M

--- a/.github/fixtures/kotlin_mode/built_in_default/settings.gradle
+++ b/.github/fixtures/kotlin_mode/built_in_default/settings.gradle
@@ -1,0 +1,13 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+rootProject.name = "flutter_image_compress_default_kotlin_fixture"
+
+include ":flutter_image_compress_common"
+project(":flutter_image_compress_common").projectDir =
+    file("../../../../packages/flutter_image_compress_common/android")

--- a/.github/fixtures/kotlin_mode/built_in_explicit/build.gradle
+++ b/.github/fixtures/kotlin_mode/built_in_explicit/build.gradle
@@ -1,0 +1,3 @@
+plugins {
+    id "com.android.library" version "9.2.1" apply false
+}

--- a/.github/fixtures/kotlin_mode/built_in_explicit/gradle.properties
+++ b/.github/fixtures/kotlin_mode/built_in_explicit/gradle.properties
@@ -1,0 +1,3 @@
+android.builtInKotlin=true
+android.newDsl=false
+org.gradle.jvmargs=-Xmx1536M

--- a/.github/fixtures/kotlin_mode/built_in_explicit/settings.gradle
+++ b/.github/fixtures/kotlin_mode/built_in_explicit/settings.gradle
@@ -1,0 +1,13 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+rootProject.name = "flutter_image_compress_built_in_kotlin_fixture"
+
+include ":flutter_image_compress_common"
+project(":flutter_image_compress_common").projectDir =
+    file("../../../../packages/flutter_image_compress_common/android")

--- a/.github/fixtures/kotlin_mode/legacy/build.gradle
+++ b/.github/fixtures/kotlin_mode/legacy/build.gradle
@@ -1,0 +1,3 @@
+plugins {
+    id "com.android.library" version "9.2.1" apply false
+}

--- a/.github/fixtures/kotlin_mode/legacy/gradle.properties
+++ b/.github/fixtures/kotlin_mode/legacy/gradle.properties
@@ -1,0 +1,3 @@
+android.builtInKotlin=false
+android.newDsl=false
+org.gradle.jvmargs=-Xmx1536M

--- a/.github/fixtures/kotlin_mode/legacy/settings.gradle
+++ b/.github/fixtures/kotlin_mode/legacy/settings.gradle
@@ -1,0 +1,13 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+rootProject.name = "flutter_image_compress_legacy_kotlin_fixture"
+
+include ":flutter_image_compress_common"
+project(":flutter_image_compress_common").projectDir =
+    file("../../../../packages/flutter_image_compress_common/android")

--- a/.github/scripts/verify_flutter_image_compress_kotlin_mode.init.gradle
+++ b/.github/scripts/verify_flutter_image_compress_kotlin_mode.init.gradle
@@ -1,0 +1,22 @@
+gradle.afterProject { project, state ->
+    if (project.name != "flutter_image_compress_common" || state.failure != null) {
+        return
+    }
+
+    def builtInKotlin = System.getProperty("flutterImageCompress.expectedBuiltInKotlin")
+    if (builtInKotlin == null) {
+        throw new GradleException("Missing expected built-in Kotlin mode")
+    }
+    def expectsBuiltInKotlin = builtInKotlin.toBoolean()
+    def appliesKotlinPlugin =
+        project.pluginManager.hasPlugin("org.jetbrains.kotlin.android") ||
+        project.pluginManager.hasPlugin("kotlin-android")
+
+    if (appliesKotlinPlugin == expectsBuiltInKotlin) {
+        throw new GradleException(
+            expectsBuiltInKotlin
+                ? "flutter_image_compress_common applied KGP in built-in Kotlin mode"
+                : "flutter_image_compress_common did not apply KGP in legacy Kotlin mode"
+        )
+    }
+}

--- a/.github/workflows/runnable.yml
+++ b/.github/workflows/runnable.yml
@@ -231,17 +231,18 @@ jobs:
 
   test_android:
     needs: analyze
-    name: Test Android on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
+    name: Test Android on ubuntu-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with:
           distribution: "zulu"
           java-version: "17"
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: "9.5.1"
+          cache-disabled: true
       - uses: subosito/flutter-action@v2
         with:
           channel: "stable"
@@ -269,7 +270,23 @@ jobs:
         run: dart pub global activate melos
       - name: Melos bootstrap
         run: melos bootstrap
-      - run: melos run try_build_apk
+      - name: Build legacy Kotlin APK
+        run: melos run try_build_apk
+      - name: Verify legacy Kotlin project
+        run: |
+          gradle -p .github/fixtures/kotlin_mode/legacy help \
+            -DflutterImageCompress.expectedBuiltInKotlin=false \
+            -I ../../../scripts/verify_flutter_image_compress_kotlin_mode.init.gradle
+      - name: Verify explicit built-in Kotlin project
+        run: |
+          gradle -p .github/fixtures/kotlin_mode/built_in_explicit help \
+            -DflutterImageCompress.expectedBuiltInKotlin=true \
+            -I ../../../scripts/verify_flutter_image_compress_kotlin_mode.init.gradle
+      - name: Verify AGP-default built-in Kotlin project
+        run: |
+          gradle -p .github/fixtures/kotlin_mode/built_in_default help \
+            -DflutterImageCompress.expectedBuiltInKotlin=true \
+            -I ../../../scripts/verify_flutter_image_compress_kotlin_mode.init.gradle
 
   test_web:
     needs: analyze

--- a/packages/flutter_image_compress/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/flutter_image_compress/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-all.zip

--- a/packages/flutter_image_compress/example/android/settings.gradle.kts
+++ b/packages/flutter_image_compress/example/android/settings.gradle.kts
@@ -19,8 +19,8 @@ pluginManagement {
 
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
-    id("com.android.application") version "9.0.1" apply false
-    id("org.jetbrains.kotlin.android") version "2.3.20" apply false
+    id("com.android.application") version "9.2.1" apply false
+    id("org.jetbrains.kotlin.android") version "2.3.21" apply false
 }
 
 include(":app")

--- a/packages/flutter_image_compress_common/android/build.gradle
+++ b/packages/flutter_image_compress_common/android/build.gradle
@@ -1,21 +1,17 @@
 group 'com.fluttercandies.flutter_image_compress'
 version '1.0-SNAPSHOT'
 
-def builtInKotlinFlag = (project.findProperty("android.builtInKotlin") ?: "false").toString().toBoolean()
-def hasKotlinExtension = project.extensions.findByName("kotlin") != null
-def useBuiltInKotlin = builtInKotlinFlag && hasKotlinExtension
+// Keep this top-level: a conditional buildscript block can run after Gradle
+// has resolved the script classpath (see issue #400).
+buildscript {
+    ext.kotlin_version = '1.8.20'
+    repositories {
+        google()
+        mavenCentral()
+    }
 
-if (!useBuiltInKotlin) {
-    buildscript {
-        ext.kotlin_version = '1.8.20'
-        repositories {
-            google()
-            mavenCentral()
-        }
-
-        dependencies {
-            classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        }
+    dependencies {
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
 
@@ -27,6 +23,17 @@ rootProject.allprojects {
 }
 
 apply plugin: 'com.android.library'
+
+// AGP creates its built-in Kotlin extension when the Android plugin is
+// applied. Checking before this point always misdetects the built-in path.
+def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0] as int
+def builtInKotlinProperty = project.findProperty("android.builtInKotlin")
+// AGP 9+ enables built-in Kotlin by default when the property is absent.
+def builtInKotlinRequested = builtInKotlinProperty == null
+        ? agpMajor >= 9
+        : builtInKotlinProperty.toString().toBoolean()
+def hasKotlinExtension = project.extensions.findByName("kotlin") != null
+def useBuiltInKotlin = builtInKotlinRequested && hasKotlinExtension
 
 if (!useBuiltInKotlin) {
     apply plugin: 'kotlin-android'


### PR DESCRIPTION
## Summary

- keep the legacy KGP dependency in a top-level buildscript block so Gradle cannot observe the classpath before it is mutated
- detect built-in Kotlin after applying the Android plugin, including the AGP 9 default when android.builtInKotlin is unset
- test legacy, explicit built-in, and default built-in Kotlin modes with Gradle 9.5.1 / AGP 9.2.1

## Verification

- reproduced the resolved-classpath failure with the previous conditional buildscript layout
- verified all three Kotlin configuration modes with JDK 17
- built the legacy-mode debug APK successfully with 132 Gradle tasks
- parsed the workflow YAML and ran git diff --check

Fixes #400