### PR TITLE
fix(Android): replace deprecated EXIF ISO tag

### DIFF
--- a/packages/flutter_image_compress_common/android/src/main/kotlin/com/fluttercandies/flutter_image_compress/exif/ExifKeeper.java
+++ b/packages/flutter_image_compress_common/android/src/main/kotlin/com/fluttercandies/flutter_image_compress/exif/ExifKeeper.java
@@ -64,7 +64,7 @@ public class ExifKeeper {
             ExifInterface.TAG_EXPOSURE_TIME,
             ExifInterface.TAG_F_NUMBER,
             ExifInterface.TAG_EXPOSURE_PROGRAM,
-            ExifInterface.TAG_ISO_SPEED_RATINGS,
+            ExifInterface.TAG_PHOTOGRAPHIC_SENSITIVITY,
             ExifInterface.TAG_SHUTTER_SPEED_VALUE,
             ExifInterface.TAG_APERTURE_VALUE,
             ExifInterface.TAG_BRIGHTNESS_VALUE,


### PR DESCRIPTION
## Related Issue

Closes #402

## Problem

Android's `ExifKeeper` referenced the deprecated `ExifInterface.TAG_ISO_SPEED_RATINGS` constant, so Java compilation emitted a deprecation note on every consumer build. The issue reproduction and maintainer follow-up confirmed that AndroidX 1.4.2 maps the legacy name to `TAG_PHOTOGRAPHIC_SENSITIVITY` for the same underlying EXIF tag.

## Changes

- Replace `TAG_ISO_SPEED_RATINGS` with `TAG_PHOTOGRAPHIC_SENSITIVITY` in the EXIF attribute copy list.
- Keep the runtime EXIF copy behavior unchanged while removing the deprecated Java API reference.

## Verification

- RED: compiled the unmodified full `ExifKeeper.java` with AndroidX 1.4.2 using `javac -Xlint:deprecation -Werror`; it failed only on `TAG_ISO_SPEED_RATINGS`.
- GREEN: reran the identical command after the change; it completed with no diagnostics.
- `dart run melos exec -- "dart format . -o none --set-exit-if-changed"` - passed, 0 files changed.
- `dart run melos run analyze` - passed for all 7 packages.
- Android `:flutter_image_compress_common:compileDebugJavaWithJavac --rerun-tasks` - passed.
- Android `assembleDebug` - passed, 178 tasks completed and `app-debug.apk` produced.
- `melos run test` is not runnable on the current `main`: all 7 packages report that their `test` directory is absent. The repository CI does not invoke this script; the affected compile path is covered directly above.

## Risk

- Low. The change is limited to one compile-time constant in `ExifKeeper`; AndroidX preserves compatibility for the same EXIF field, so image metadata behavior is unchanged.

## Standards

- Followed `CONTRIBUTING.md` for the `main` target and Conventional Commit format.
- Followed `.github/workflows/runnable.yml` for format, analysis, and Android build verification.
- The repository has no PR template or agent-specific instruction file, so the general PR structure was used.
